### PR TITLE
Codahale -> Dropwizard updates.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.opentable</groupId>
     <artifactId>otj-parent</artifactId>
-    <version>39</version>
+    <version>49</version>
   </parent>
 
   <scm>
@@ -45,7 +45,7 @@
     <dependency>
       <groupId>com.opentable.components</groupId>
       <artifactId>otj-executors</artifactId>
-      <version>1.0.1</version>
+      <version>1.0.2</version>
     </dependency>
 
     <dependency>
@@ -73,31 +73,31 @@
     </dependency>
 
     <dependency>
-      <groupId>com.codahale.metrics</groupId>
+      <groupId>io.dropwizard.metrics</groupId>
       <artifactId>metrics-core</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.codahale.metrics</groupId>
+      <groupId>io.dropwizard.metrics</groupId>
       <artifactId>metrics-jvm</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.codahale.metrics</groupId>
+      <groupId>io.dropwizard.metrics</groupId>
       <artifactId>metrics-json</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.codahale.metrics</groupId>
+      <groupId>io.dropwizard.metrics</groupId>
       <artifactId>metrics-jetty9</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.codahale.metrics</groupId>
+      <groupId>io.dropwizard.metrics</groupId>
       <artifactId>metrics-healthchecks</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.codahale.metrics</groupId>
+      <groupId>io.dropwizard.metrics</groupId>
       <artifactId>metrics-servlets</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.codahale.metrics</groupId>
+      <groupId>io.dropwizard.metrics</groupId>
       <artifactId>metrics-graphite</artifactId>
     </dependency>
 


### PR DESCRIPTION
When updating Guava to a later version, we discovered that there were
now conflicting classes for various Codahale metrics libraries.  This
led us to discover that the project started out as one of Coda's
personal projects; it used class namespace `com.codahale.metrics`.  He
was working at Yammer at the time, and the project became sufficiently
important for them to change its packaging to be associated with Yammer.
When they did this, they _changed_ the class namespace to
`com.yammer.metrics`.  Later, the project became sufficiently valuable
to the community that they open-sourced it.  On doing this, though, they
_changed the class namespace _back__ to `com.codahale.metrics` despite
the fact that the artifact `groupId` changed yet again to
`io.dropwizard.metrics`.  (wtf!)  We want only the modern Dropwizard
artifacts.

[See more here.](https://groups.google.com/d/msg/dropwizard-user/1usH7frpnZE/RSQUsOBFMsoJ)
