### PR TITLE
Increase default queue size 128 -> 32768

### DIFF
--- a/src/main/java/com/opentable/metrics/JettyServerMetricsConfiguration.java
+++ b/src/main/java/com/opentable/metrics/JettyServerMetricsConfiguration.java
@@ -43,7 +43,7 @@ public class JettyServerMetricsConfiguration {
     private static final String PREFIX = "http-server";
 
     @Bean
-    public Provider<QueuedThreadPool> getIQTPProvider(final MetricRegistry metricRegistry, @Value("${ot.httpserver.queue-size:128}") int qSize) {
+    public Provider<QueuedThreadPool> getIQTPProvider(final MetricRegistry metricRegistry, @Value("${ot.httpserver.queue-size:32768}") int qSize) {
         return () -> {
             final InstrumentedQueuedThreadPool pool = new OTQueuedThreadPool(metricRegistry, qSize);
             pool.setName("default-pool");


### PR DESCRIPTION
There's mounting evidence that rejecting enqueue operations
that refer to Jetty resources has Really Bad Effects (leaked FD,
lost connections, etc)

Analysis of queue contents shows that each individual element is quite small
(an object with a couple of fields that point to already heap-resident objects).

Even at a generous 128 bytes per element, 32768 * 128 bytes ≈ 4MB, so we might
have to purchase a couple of more floppies to increase this default.