### PR TITLE
Distinguishes between disconnected & connection fail.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 otj-metrics
 ===========
 
+2.6.11
+------
+
+* Improves compatibility with Dropwizard Metrics 3.2.3
+
 2.6.10
 ------
 


### PR DESCRIPTION
[OTPL-1963][1]

[1]: https://opentable.atlassian.net/browse/OTPL-1963

In order to accomplish Java 9 compatibility in the A/B aggregator, we need to bump up a version of a dependent library.  That dependent library requires a newer version of Dropwizard metrics.  The newer version of Dropwizard metrics uses the Graphite instances differently.  Specifically, it connects and disconnects *every* time it reports.  This commit updates our sender wrapper to be more compatible with this mode of operation, while still maintaining backwards-compatibility.