### PR TITLE
DropWizard 4 [Do Not Merge]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,15 @@
 otj-metrics
 ===========
 
+4.0.0
+-----
+* Uses DropWizard 4.0.2
+
+This is an incompatible binary/source change, which will require users to import new versions, and a new 
+module (metrics-jmx)
+
+In addition, a fork of metrics-spring will probably be needed
+
 2.6.12
 ------
 * Use non deprecated concurrent HashSet.

--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
 
   <properties>
     <!-- Upgrade DropWizard Metrics -->
-    <dep.metrics.version>4.0.2</dep.metrics.version>
+    <dep.metrics.version>4.0.3</dep.metrics.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -32,15 +32,18 @@
   <groupId>com.opentable.components</groupId>
   <artifactId>otj-metrics</artifactId>
   <name>otj-metrics</name>
-  <version>2.6.13-SNAPSHOT</version>
+  <!-- Reflect the new version -->
+  <version>4.0.0-SNAPSHOT</version>
   <packaging>jar</packaging>
   <description>Expose Codahale Metrics over HTTP in OpenTable format</description>
 
   <properties>
+    <!-- Upgrade DropWizard Metrics -->
     <dep.metrics.version>4.0.2</dep.metrics.version>
   </properties>
   <dependencyManagement>
     <dependencies>
+      <!-- In addition, we need to add this module, since JMXReporter and friends were moved -->
       <dependency>
         <groupId>io.dropwizard.metrics</groupId>
         <artifactId>metrics-jmx</artifactId>
@@ -145,6 +148,7 @@
       <groupId>io.dropwizard.metrics</groupId>
       <artifactId>metrics-annotation</artifactId>
     </dependency>
+    <!-- TODO: This probably needs to be forked thanks to the JMX Changes -->
     <dependency>
       <groupId>com.ryantenney.metrics</groupId>
       <artifactId>metrics-spring</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -40,6 +40,8 @@
   <properties>
     <!-- Upgrade DropWizard Metrics -->
     <dep.metrics.version>4.0.3</dep.metrics.version>
+    <!-- This will be the new property in future pom, and old one will be ignored, deliberately forcing a break -->
+    <dep.metrics4.version>4.0.3</dep.metrics4.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,8 @@
     <!-- This will be the new property in future pom, and old one will be ignored, deliberately forcing a break -->
     <dep.metrics4.version>4.0.3</dep.metrics4.version>
     <!-- This wasn't managed before but should have been -->
-    <dep.metrics-spring.version>3.1.3</dep.metrics-spring.version>
+    <!-- Last non forked release was 3.1.3, we now start at 3.9.9, the next release being 3.9.9.1, etc -->
+    <dep.metrics-spring.version>3.9.9</dep.metrics-spring.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
       <dependency>
         <groupId>io.dropwizard.metrics</groupId>
         <artifactId>metrics-jmx</artifactId>
-        <version>${dep.metrics.version}</version>
+        <version>${dep.metrics4.version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -223,5 +223,10 @@
       <artifactId>spring-test</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-simple</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>com.opentable</groupId>
     <artifactId>otj-parent-spring</artifactId>
-    <version>139</version>
+    <version>174</version>
   </parent>
 
   <scm>
@@ -35,7 +35,19 @@
   <version>2.6.13-SNAPSHOT</version>
   <packaging>jar</packaging>
   <description>Expose Codahale Metrics over HTTP in OpenTable format</description>
-  
+
+  <properties>
+    <dep.metrics.version>4.0.2</dep.metrics.version>
+  </properties>
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>io.dropwizard.metrics</groupId>
+        <artifactId>metrics-jmx</artifactId>
+        <version>${dep.metrics.version}</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
   <dependencies>
     <dependency>
       <groupId>com.opentable.components</groupId>
@@ -124,6 +136,10 @@
     <dependency>
       <groupId>io.dropwizard.metrics</groupId>
       <artifactId>metrics-graphite</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.dropwizard.metrics</groupId>
+      <artifactId>metrics-jmx</artifactId>
     </dependency>
     <dependency>
       <groupId>io.dropwizard.metrics</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -42,6 +42,8 @@
     <dep.metrics.version>4.0.3</dep.metrics.version>
     <!-- This will be the new property in future pom, and old one will be ignored, deliberately forcing a break -->
     <dep.metrics4.version>4.0.3</dep.metrics4.version>
+    <!-- This wasn't managed before but should have been -->
+    <dep.metrics-spring.version>3.1.3</dep.metrics-spring.version>
   </properties>
   <dependencyManagement>
     <dependencies>
@@ -158,7 +160,7 @@
         Unfortunately, this version doesn't line up exactly with the
         io.dropwizard.metrics artifacts.
       -->
-      <version>3.1.3</version>
+      <version>${dep.metrics-spring.version}</version>
     </dependency>
 
     <dependency>

--- a/src/main/java/com/opentable/metrics/AtomicDoubleGauge.java
+++ b/src/main/java/com/opentable/metrics/AtomicDoubleGauge.java
@@ -21,6 +21,7 @@ import com.codahale.metrics.Gauge;
  * A gauge that holds a double value in an atomic reference
  */
 public class AtomicDoubleGauge extends AtomicReference<Double> implements Gauge<Double> {
+    private static final int serialVersionUID = 1;
     @Override
     public Double getValue() {
         return get();

--- a/src/main/java/com/opentable/metrics/MetricsJmxExporter.java
+++ b/src/main/java/com/opentable/metrics/MetricsJmxExporter.java
@@ -18,8 +18,8 @@ import javax.annotation.PreDestroy;
 import javax.inject.Inject;
 import javax.management.MBeanServer;
 
-import com.codahale.metrics.JmxReporter;
 import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.jmx.JmxReporter;
 
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;

--- a/src/main/java/com/opentable/metrics/graphite/GraphiteConfiguration.java
+++ b/src/main/java/com/opentable/metrics/graphite/GraphiteConfiguration.java
@@ -18,12 +18,14 @@ import java.time.Duration;
 import java.util.Arrays;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
 
 import javax.annotation.PreDestroy;
 
 import com.codahale.metrics.MetricFilter;
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.MetricSet;
+import com.codahale.metrics.graphite.Graphite;
 import com.codahale.metrics.graphite.GraphiteReporter;
 import com.codahale.metrics.graphite.GraphiteSender;
 import com.google.common.annotations.VisibleForTesting;
@@ -108,8 +110,9 @@ public class GraphiteConfiguration {
             LOG.info("no graphite host; skipping sender initialization");
             return null;
         }
-
-        GraphiteSenderWrapper result = new GraphiteSenderWrapper(() -> new InetSocketAddress(host, port));
+        final Supplier<InetSocketAddress> address = () -> new InetSocketAddress(host, port);
+        final Graphite graphite = new Graphite(address.get());
+        GraphiteSenderWrapper result = new GraphiteSenderWrapper(address, graphite);
         registeredMetrics = MetricSets.combineAndPrefix(PREFIX, result);
         metricRegistry.registerAll(registeredMetrics);
         return result;

--- a/src/main/java/com/opentable/metrics/graphite/GraphiteSenderWrapper.java
+++ b/src/main/java/com/opentable/metrics/graphite/GraphiteSenderWrapper.java
@@ -123,7 +123,7 @@ public class GraphiteSenderWrapper implements GraphiteSender, Closeable, MetricS
     private synchronized Graphite delegate() throws IOException {
         final boolean explicitlyClosed = delegate == null;
         boolean needsReconnectFail = false;
-        if (explicitlyClosed || (needsReconnectFail = needsReconnectFail(delegate)) || needsReconnectPeriodic()) {
+        if (explicitlyClosed || (needsReconnectFail = needsReconnectFail(delegate)) || needsReconnectPeriodic()) { //NOPMD
             if (needsReconnectFail) {
                 connectionFailures.inc();
                 LOG.warn("bad graphite state; recycling; connected {}, failures {}; counter {}; last @ {}",

--- a/src/test/java/com/opentable/metrics/MetricSetBuilderTest.java
+++ b/src/test/java/com/opentable/metrics/MetricSetBuilderTest.java
@@ -101,6 +101,7 @@ public class MetricSetBuilderTest {
 
 
     @Test
+    // For some reason, this has started failing from the command line only.
     public void testEventRegister() {
         final MetricRegistry registry;
         try (ConfigurableApplicationContext ctx = new AnnotationConfigApplicationContext(EventRegister.class)) {
@@ -110,6 +111,8 @@ public class MetricSetBuilderTest {
             ctx.getBean(ApplicationEventMulticaster.class).multicastEvent(new ApplicationReadyEvent(new SpringApplication(), new String[0], ctx));
             assertThat(registry.getMetrics())
                 .containsKeys(EXPECTED);
+            // Not sure why, but this fixes - seems like the event doesn't get propagated properly otherwise.
+            ctx.close();
         }
         assertThat(registry.getMetrics()).doesNotContainKeys(EXPECTED);
     }


### PR DESCRIPTION
Can be merged (refactored) after other stuff
Required for Spring Boot 2.1

Basic Changes were simple in theory
1. Bump version
2. Add metrics-jmx
3. Change package .of JMXReporter (this is what breaks source and binary compatibility)

However most of a day was spent exploring why the Reconnect tests failed.

In turns out due to https://github.com/dropwizard/metrics/issues/694
that all versions of DW from 3.1.3+ (3.1.2 is currently used), including the 3.2.3 override (abtest clients) were failing, because most of the logic of GraphiteSenderWrapper is redundant and broken in a refactored GraphiteReporter that connects/closes on every reporting period. Hence much of that class was gutted. Even the hourly reconnect I suspect no longer serves a purpose.

Remaining:
- Test on Service-Demo. Namespaces and all metrics should continue to be unaffected
- metrics-spring. We use this library to enable the annotations like @Timed, which are just bare annotations with no innate functionality. Problem is it is mostly abandoned, and we'll need to fork it to fix it for DropWizard 4. https://github.com/ryantenney/metrics-spring/pull/217 gives us most of what we need and it's simple enough. It's a bit unclear to me reading through that the affected classes are even used by us but ...
- otj-parent that simply initially copies dep.metrics.version to dep.metrics4.version and changes usage to dep.metrics4.version. Still remaining on v3, this makes it impossible to override later - which would be fatal (a backrev)
- Test elsewhere
- otj-parent that switches entirely

