### PR TITLE
Do not log metric registration on empty metric set

### DIFF
--- a/src/main/java/com/opentable/metrics/DefaultMetricsConfiguration.java
+++ b/src/main/java/com/opentable/metrics/DefaultMetricsConfiguration.java
@@ -101,9 +101,11 @@ public class DefaultMetricsConfiguration {
             List<MetricSet> metrics = findEventedMetricSets()
                 .filter(m -> m.getEventClass().isInstance(event))
                 .collect(Collectors.toList());
-            LOG.debug("Registering metrics on event {}: {}", event, metrics);
-            metrics.forEach(registry::registerAll);
-            metrics.forEach(m -> registeredMetrics.addAll(m.getMetrics().keySet()));
+            if (!metrics.isEmpty()) {
+                LOG.debug("Registering metrics on event {}: {}", event, metrics);
+                metrics.forEach(registry::registerAll);
+                metrics.forEach(m -> registeredMetrics.addAll(m.getMetrics().keySet()));
+            }
         };
     }
 


### PR DESCRIPTION
In spring, ServletProcessingFinished event is fired after each request and we are filling up logs with  messages "Registering metrics on event..."