### PR TITLE
Add health and service-status endpoints for Reactive HTTP servers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 otj-metrics
 ===========
+
+4.0.4
+-----
+* Add health and service-status endpoints for Reactive HTTP servers.
+
 4.0.3
 -----
 * Report extended counters for "Metered" and "Histogram"

--- a/otj-metrics-core/pom.xml
+++ b/otj-metrics-core/pom.xml
@@ -39,7 +39,10 @@
             <groupId>com.opentable.components</groupId>
             <artifactId>otj-jvm</artifactId>
         </dependency>
-
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+        </dependency>
         <dependency>
             <groupId>com.opentable.components</groupId>
             <artifactId>otj-spring</artifactId>

--- a/otj-metrics-core/pom.xml
+++ b/otj-metrics-core/pom.xml
@@ -39,10 +39,12 @@
             <groupId>com.opentable.components</groupId>
             <artifactId>otj-jvm</artifactId>
         </dependency>
+
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
         </dependency>
+
         <dependency>
             <groupId>com.opentable.components</groupId>
             <artifactId>otj-spring</artifactId>

--- a/otj-metrics-core/src/main/java/com/opentable/metrics/SortedEntry.java
+++ b/otj-metrics-core/src/main/java/com/opentable/metrics/SortedEntry.java
@@ -1,0 +1,55 @@
+package com.opentable.metrics;
+
+import com.codahale.metrics.health.HealthCheck;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.google.common.collect.ComparisonChain;
+
+import org.apache.commons.lang3.builder.EqualsBuilder;
+
+import com.opentable.metrics.http.HealthController;
+
+public class SortedEntry implements Comparable<SortedEntry> {
+    final String name;
+    final HealthCheck.Result result;
+
+    public SortedEntry(String name, HealthCheck.Result result) {
+        this.name = name;
+        this.result = result;
+    }
+
+    @Override
+    public int compareTo(SortedEntry o) {
+        return ComparisonChain.start()
+                // severity descending
+                .compare(o.result, result, HealthController::compare)
+                // name ascending
+                .compare(name, o.name)
+                .result();
+    }
+
+
+    public HealthCheck.Result getResult() {
+        return result;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public int hashCode() {
+        return name.hashCode();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        return EqualsBuilder.reflectionEquals(this, obj, false);
+    }
+
+    @Override
+    @JsonValue
+    public String toString() {
+        return name;
+    }
+
+}

--- a/otj-metrics-jaxrs/pom.xml
+++ b/otj-metrics-jaxrs/pom.xml
@@ -48,11 +48,6 @@
         </dependency>
 
         <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-annotations</artifactId>
-        </dependency>
-
-        <dependency>
             <groupId>io.dropwizard.metrics</groupId>
             <artifactId>metrics-healthchecks</artifactId>
         </dependency>

--- a/otj-metrics-jaxrs/src/main/java/com/opentable/metrics/jaxrs/HealthResource.java
+++ b/otj-metrics-jaxrs/src/main/java/com/opentable/metrics/jaxrs/HealthResource.java
@@ -28,13 +28,11 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
 import com.codahale.metrics.health.HealthCheck.Result;
-import com.fasterxml.jackson.annotation.JsonValue;
-import com.google.common.collect.ComparisonChain;
 
 import org.apache.commons.lang3.ClassUtils;
-import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.tuple.Pair;
 
+import com.opentable.metrics.SortedEntry;
 import com.opentable.metrics.http.CheckState;
 import com.opentable.metrics.http.HealthController;
 
@@ -72,52 +70,13 @@ public class HealthResource {
         });
 
         if (!all && !rendered.isEmpty()) {
-            Result worstResult = rendered.keySet().iterator().next().result;
+            Result worstResult = rendered.keySet().iterator().next().getResult();
             if (!worstResult.isHealthy()) {
-                rendered.keySet().removeIf(e -> e.result.isHealthy());
+                rendered.keySet().removeIf(e -> e.getResult().isHealthy());
             }
         }
 
         return rendered;
     }
 
-    public static class SortedEntry implements Comparable<SortedEntry> {
-        private final String name;
-        final Result result;
-
-        SortedEntry(String name, Result result) {
-            this.name = name;
-            this.result = result;
-        }
-
-        public String getName() {
-            return name;
-        }
-
-        @Override
-        public int compareTo(SortedEntry o) {
-            return ComparisonChain.start()
-                    // severity descending
-                    .compare(o.result, result, HealthController::compare)
-                    // name ascending
-                    .compare(getName(), o.getName())
-                    .result();
-        }
-
-        @Override
-        public int hashCode() {
-            return getName().hashCode();
-        }
-
-        @Override
-        public boolean equals(Object obj) {
-            return EqualsBuilder.reflectionEquals(this, obj, false);
-        }
-
-        @Override
-        @JsonValue
-        public String toString() {
-            return getName();
-        }
-    }
 }

--- a/otj-metrics-jaxrs/src/main/java/com/opentable/metrics/jaxrs/HealthResource.java
+++ b/otj-metrics-jaxrs/src/main/java/com/opentable/metrics/jaxrs/HealthResource.java
@@ -15,7 +15,6 @@ package com.opentable.metrics.jaxrs;
 
 
 import java.util.Map;
-import java.util.TreeMap;
 
 import javax.inject.Named;
 import javax.ws.rs.DefaultValue;
@@ -29,7 +28,6 @@ import javax.ws.rs.core.Response;
 
 import com.codahale.metrics.health.HealthCheck.Result;
 
-import org.apache.commons.lang3.ClassUtils;
 import org.apache.commons.lang3.tuple.Pair;
 
 import com.opentable.metrics.SortedEntry;
@@ -50,7 +48,7 @@ public class HealthResource {
     @Path("/")
     public Response getHealth(@QueryParam("all") @DefaultValue("false") boolean all) {
         final Pair<Map<String, Result>, CheckState> result = controller.runHealthChecks();
-        return Response.status(result.getRight().getHttpStatus()).entity(render(all, result.getLeft())).build();
+        return Response.status(result.getRight().getHttpStatus()).entity(SortedEntry.render(all, result.getLeft())).build();
     }
 
     @GET
@@ -60,23 +58,7 @@ public class HealthResource {
         if (result == null) {
             return Response.status(404).build();
         }
-        return Response.status(result.getRight().getHttpStatus()).entity(render(all, result.getLeft())).build();
-    }
-
-    private Map<SortedEntry, Result> render(boolean all, Map<String, Result> raw) {
-        Map<SortedEntry, Result> rendered = new TreeMap<>();
-        raw.forEach((name, result) -> {
-            rendered.put(new SortedEntry(ClassUtils.getAbbreviatedName(name, 20), result), result);
-        });
-
-        if (!all && !rendered.isEmpty()) {
-            Result worstResult = rendered.keySet().iterator().next().getResult();
-            if (!worstResult.isHealthy()) {
-                rendered.keySet().removeIf(e -> e.getResult().isHealthy());
-            }
-        }
-
-        return rendered;
+        return Response.status(result.getRight().getHttpStatus()).entity(SortedEntry.render(all, result.getLeft())).build();
     }
 
 }

--- a/otj-metrics-jaxrs/src/test/java/com/opentable/metrics/jaxrs/HealthApiTest.java
+++ b/otj-metrics-jaxrs/src/test/java/com/opentable/metrics/jaxrs/HealthApiTest.java
@@ -30,9 +30,8 @@ import com.google.common.util.concurrent.MoreExecutors;
 import org.junit.Test;
 import org.springframework.mock.env.MockEnvironment;
 
+import com.opentable.metrics.SortedEntry;
 import com.opentable.metrics.http.HealthController;
-import com.opentable.metrics.jaxrs.HealthResource;
-import com.opentable.metrics.jaxrs.HealthResource.SortedEntry;
 
 public class HealthApiTest {
     private final HealthCheckRegistry registry = new HealthCheckRegistry();
@@ -144,7 +143,7 @@ public class HealthApiTest {
         Map<?, ?> result = (Map<?,?>) r.getEntity();
         assertEquals(ImmutableList.of("c", "b"), result.keySet().stream()
                 .map(e -> SortedEntry.class.cast(e))
-                .map(e -> e.getName())
+                .map(SortedEntry::getName)
                 .collect(Collectors.toList()));
         r.close();
     }

--- a/otj-metrics-mvc/pom.xml
+++ b/otj-metrics-mvc/pom.xml
@@ -47,18 +47,8 @@
         </dependency>
 
         <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-        </dependency>
-
-        <dependency>
             <groupId>io.dropwizard.metrics</groupId>
             <artifactId>metrics-core</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-annotations</artifactId>
         </dependency>
 
         <dependency>

--- a/otj-metrics-mvc/src/main/java/com/opentable/metrics/mvc/HealthEndpoint.java
+++ b/otj-metrics-mvc/src/main/java/com/opentable/metrics/mvc/HealthEndpoint.java
@@ -14,11 +14,9 @@
 package com.opentable.metrics.mvc;
 
 import java.util.Map;
-import java.util.TreeMap;
 
 import com.codahale.metrics.health.HealthCheck.Result;
 
-import org.apache.commons.lang3.ClassUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
@@ -42,7 +40,7 @@ public class HealthEndpoint {
     @GetMapping
     public ResponseEntity<Map<SortedEntry, Result>> getHealth(@RequestParam(name="all", defaultValue="false") boolean all) {
         final Pair<Map<String, Result>, CheckState> result = controller.runHealthChecks();
-        return ResponseEntity.status(result.getRight().getHttpStatus()).body(render(all, result.getLeft()));
+        return ResponseEntity.status(result.getRight().getHttpStatus()).body(SortedEntry.render(all, result.getLeft()));
     }
 
     @GetMapping("/group/{group}")
@@ -51,22 +49,6 @@ public class HealthEndpoint {
         if (result == null) {
             return ResponseEntity.notFound().build();
         }
-        return ResponseEntity.status(result.getRight().getHttpStatus()).body(render(all, result.getLeft()));
-    }
-
-    private Map<SortedEntry, Result> render(boolean all, Map<String, Result> raw) {
-        Map<SortedEntry, Result> rendered = new TreeMap<>();
-        raw.forEach((name, result) -> {
-            rendered.put(new SortedEntry(ClassUtils.getAbbreviatedName(name, 20), result), result);
-        });
-
-        if (!all && !rendered.isEmpty()) {
-            Result worstResult = rendered.keySet().iterator().next().getResult();
-            if (!worstResult.isHealthy()) {
-                rendered.keySet().removeIf(e -> e.getResult().isHealthy());
-            }
-        }
-
-        return rendered;
+        return ResponseEntity.status(result.getRight().getHttpStatus()).body(SortedEntry.render(all, result.getLeft()));
     }
 }

--- a/otj-metrics-mvc/src/main/java/com/opentable/metrics/mvc/HealthEndpoint.java
+++ b/otj-metrics-mvc/src/main/java/com/opentable/metrics/mvc/HealthEndpoint.java
@@ -17,11 +17,8 @@ import java.util.Map;
 import java.util.TreeMap;
 
 import com.codahale.metrics.health.HealthCheck.Result;
-import com.fasterxml.jackson.annotation.JsonValue;
-import com.google.common.collect.ComparisonChain;
 
 import org.apache.commons.lang3.ClassUtils;
-import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.tuple.Pair;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
@@ -31,6 +28,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.opentable.metrics.SortedEntry;
 import com.opentable.metrics.http.CheckState;
 import com.opentable.metrics.http.HealthController;
 
@@ -63,48 +61,12 @@ public class HealthEndpoint {
         });
 
         if (!all && !rendered.isEmpty()) {
-            Result worstResult = rendered.keySet().iterator().next().result;
+            Result worstResult = rendered.keySet().iterator().next().getResult();
             if (!worstResult.isHealthy()) {
-                rendered.keySet().removeIf(e -> e.result.isHealthy());
+                rendered.keySet().removeIf(e -> e.getResult().isHealthy());
             }
         }
 
         return rendered;
-    }
-
-    static class SortedEntry implements Comparable<SortedEntry> {
-        final String name;
-        final Result result;
-
-        SortedEntry(String name, Result result) {
-            this.name = name;
-            this.result = result;
-        }
-
-        @Override
-        public int compareTo(SortedEntry o) {
-            return ComparisonChain.start()
-                    // severity descending
-                    .compare(o.result, result, HealthController::compare)
-                    // name ascending
-                    .compare(name, o.name)
-                    .result();
-        }
-
-        @Override
-        public int hashCode() {
-            return name.hashCode();
-        }
-
-        @Override
-        public boolean equals(Object obj) {
-            return EqualsBuilder.reflectionEquals(this, obj, false);
-        }
-
-        @Override
-        @JsonValue
-        public String toString() {
-            return name;
-        }
     }
 }

--- a/otj-metrics-reactive/pom.xml
+++ b/otj-metrics-reactive/pom.xml
@@ -47,18 +47,8 @@
         </dependency>
 
         <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-        </dependency>
-
-        <dependency>
             <groupId>io.dropwizard.metrics</groupId>
             <artifactId>metrics-core</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-annotations</artifactId>
         </dependency>
 
         <dependency>

--- a/otj-metrics-reactive/pom.xml
+++ b/otj-metrics-reactive/pom.xml
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+~   Licensed under the Apache License, Version 2.0 (the "License");
+~   you may not use this file except in compliance with the License.
+~   You may obtain a copy of the License at
+~
+~   http://www.apache.org/licenses/LICENSE-2.0
+~
+~   Unless required by applicable law or agreed to in writing, software
+~   distributed under the License is distributed on an "AS IS" BASIS,
+~   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+~   See the License for the specific language governing permissions and
+~   limitations under the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>com.opentable.components</groupId>
+        <artifactId>otj-metrics-parent</artifactId>
+        <version>4.0.4-SNAPSHOT</version>
+    </parent>
+    <artifactId>otj-metrics-reactive</artifactId>
+    <name>OpenTable Metrics Reactive</name>
+    <description>Exposes metrics over Spring WebFlux reactive endpoints</description>
+
+    <dependencies>
+
+        <dependency>
+            <groupId>com.opentable.components</groupId>
+            <artifactId>otj-metrics-core</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-web</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-beans</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.dropwizard.metrics</groupId>
+            <artifactId>metrics-core</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-context</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.dropwizard.metrics</groupId>
+            <artifactId>metrics-healthchecks</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.projectreactor</groupId>
+            <artifactId>reactor-core</artifactId>
+        </dependency>
+
+    </dependencies>
+
+</project>

--- a/otj-metrics-reactive/src/main/java/com/opentable/metrics/reactive/HealthEndpoint.java
+++ b/otj-metrics-reactive/src/main/java/com/opentable/metrics/reactive/HealthEndpoint.java
@@ -1,0 +1,105 @@
+package com.opentable.metrics.reactive;
+
+import static com.codahale.metrics.health.HealthCheck.Result;
+
+import java.util.Map;
+import java.util.TreeMap;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.google.common.collect.ComparisonChain;
+
+import org.apache.commons.lang3.ClassUtils;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.tuple.Pair;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import reactor.core.publisher.Mono;
+
+import com.opentable.metrics.http.CheckState;
+import com.opentable.metrics.http.HealthController;
+
+/**
+ * Health endpoint for Reactive HTTP servers.
+ */
+@RestController
+@RequestMapping("/health")
+public class HealthEndpoint {
+
+    private final HealthController controller;
+
+    public HealthEndpoint(HealthController controller) {
+        this.controller = controller;
+    }
+
+    @GetMapping
+    public Mono<ResponseEntity<Map<SortedEntry, Result>>> getHealth(@RequestParam(name="all", defaultValue="false") boolean all) {
+        final Pair<Map<String, Result>, CheckState> result = controller.runHealthChecks();
+        return Mono.just(ResponseEntity.status(result.getRight().getHttpStatus()).body(render(all, result.getLeft())));
+    }
+
+    @GetMapping("/group/{group}")
+    public Mono<ResponseEntity<?>> getHealthGroup(@PathVariable("group") String group, @RequestParam(name="all", defaultValue="false") boolean all) {
+        final Pair<Map<String, Result>, CheckState> result = controller.runHealthChecks(group);
+        if (result == null) {
+            return Mono.just(ResponseEntity.notFound().build());
+        }
+        return Mono.just(ResponseEntity.status(result.getRight().getHttpStatus()).body(render(all, result.getLeft())));
+    }
+
+    private Map<SortedEntry, Result> render(boolean all, Map<String, Result> raw) {
+        Map<SortedEntry, Result> rendered = new TreeMap<>();
+        raw.forEach((name, result) -> {
+            rendered.put(new SortedEntry(ClassUtils.getAbbreviatedName(name, 20), result), result);
+        });
+
+        if (!all && !rendered.isEmpty()) {
+            Result worstResult = rendered.keySet().iterator().next().result;
+            if (!worstResult.isHealthy()) {
+                rendered.keySet().removeIf(e -> e.result.isHealthy());
+            }
+        }
+
+        return rendered;
+    }
+
+    static class SortedEntry implements Comparable<SortedEntry> {
+        final String name;
+        final Result result;
+
+        SortedEntry(String name, Result result) {
+            this.name = name;
+            this.result = result;
+        }
+
+        @Override
+        public int compareTo(SortedEntry o) {
+            return ComparisonChain.start()
+                    // severity descending
+                    .compare(o.result, result, HealthController::compare)
+                    // name ascending
+                    .compare(name, o.name)
+                    .result();
+        }
+
+        @Override
+        public int hashCode() {
+            return name.hashCode();
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            return EqualsBuilder.reflectionEquals(this, obj, false);
+        }
+
+        @Override
+        @JsonValue
+        public String toString() {
+            return name;
+        }
+    }
+}

--- a/otj-metrics-reactive/src/main/java/com/opentable/metrics/reactive/HealthEndpoint.java
+++ b/otj-metrics-reactive/src/main/java/com/opentable/metrics/reactive/HealthEndpoint.java
@@ -3,9 +3,7 @@ package com.opentable.metrics.reactive;
 import static com.codahale.metrics.health.HealthCheck.Result;
 
 import java.util.Map;
-import java.util.TreeMap;
 
-import org.apache.commons.lang3.ClassUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -36,7 +34,7 @@ public class HealthEndpoint {
     @GetMapping
     public Mono<ResponseEntity<Map<SortedEntry, Result>>> getHealth(@RequestParam(name="all", defaultValue="false") boolean all) {
         final Pair<Map<String, Result>, CheckState> result = controller.runHealthChecks();
-        return Mono.just(ResponseEntity.status(result.getRight().getHttpStatus()).body(render(all, result.getLeft())));
+        return Mono.just(ResponseEntity.status(result.getRight().getHttpStatus()).body(SortedEntry.render(all, result.getLeft())));
     }
 
     @GetMapping("/group/{group}")
@@ -45,23 +43,7 @@ public class HealthEndpoint {
         if (result == null) {
             return Mono.just(ResponseEntity.notFound().build());
         }
-        return Mono.just(ResponseEntity.status(result.getRight().getHttpStatus()).body(render(all, result.getLeft())));
-    }
-
-    private Map<SortedEntry, Result> render(boolean all, Map<String, Result> raw) {
-        Map<SortedEntry, Result> rendered = new TreeMap<>();
-        raw.forEach((name, result) -> {
-            rendered.put(new SortedEntry(ClassUtils.getAbbreviatedName(name, 20), result), result);
-        });
-
-        if (!all && !rendered.isEmpty()) {
-            Result worstResult = rendered.keySet().iterator().next().getResult();
-            if (!worstResult.isHealthy()) {
-                rendered.keySet().removeIf(e -> e.getResult().isHealthy());
-            }
-        }
-
-        return rendered;
+        return Mono.just(ResponseEntity.status(result.getRight().getHttpStatus()).body(SortedEntry.render(all, result.getLeft())));
     }
 
 }

--- a/otj-metrics-reactive/src/main/java/com/opentable/metrics/reactive/HealthHttpReactiveConfiguration.java
+++ b/otj-metrics-reactive/src/main/java/com/opentable/metrics/reactive/HealthHttpReactiveConfiguration.java
@@ -1,0 +1,14 @@
+package com.opentable.metrics.reactive;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+
+import com.opentable.metrics.http.HealthController;
+
+@Configuration
+@Import({
+        HealthController.class,
+        HealthEndpoint.class,
+})
+public class HealthHttpReactiveConfiguration {
+}

--- a/otj-metrics-reactive/src/main/java/com/opentable/metrics/reactive/MetricsHttpEndpoint.java
+++ b/otj-metrics-reactive/src/main/java/com/opentable/metrics/reactive/MetricsHttpEndpoint.java
@@ -1,0 +1,94 @@
+package com.opentable.metrics.reactive;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.codahale.metrics.Counter;
+import com.codahale.metrics.Gauge;
+import com.codahale.metrics.Histogram;
+import com.codahale.metrics.Meter;
+import com.codahale.metrics.Metric;
+import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.Timer;
+import com.codahale.metrics.health.HealthCheck;
+import com.codahale.metrics.health.HealthCheckRegistry;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import reactor.core.publisher.Mono;
+
+import com.opentable.metrics.http.CounterResponse;
+import com.opentable.metrics.http.GaugeResponse;
+import com.opentable.metrics.http.HealthCheckResponse;
+import com.opentable.metrics.http.HistogramResponse;
+import com.opentable.metrics.http.MeterResponse;
+import com.opentable.metrics.http.MonitorResponse;
+import com.opentable.metrics.http.TimerResponse;
+
+/**
+ * Metrics endpoint for Reactive HTTP servers.
+ */
+@RestController
+@RequestMapping("/service-status")
+public class MetricsHttpEndpoint {
+
+    private final MetricRegistry metrics;
+    private final HealthCheckRegistry health;
+
+    @Autowired
+    public MetricsHttpEndpoint(MetricRegistry metrics, HealthCheckRegistry health) {
+        this.metrics = metrics;
+        this.health = health;
+    }
+
+    @GetMapping
+    public Mono<List<MonitorResponse>> get()
+    {
+        final List<MonitorResponse> responses = new ArrayList<>();
+        metrics.getMetrics().forEach((n, m) -> responses.add(toResponse(n, m)));
+        health.runHealthChecks().forEach((n, r) -> responses.add(toResponse(n, r)));
+        return Mono.just(responses);
+    }
+
+    @GetMapping("/{metricName}")
+    public Mono<MonitorResponse> get(@PathVariable("metricName") String metricName)
+    {
+        final Metric metric = metrics.getMetrics().get(metricName);
+        if (metric != null) {
+            return Mono.just(toResponse(metricName, metric));
+        }
+        if (health.getNames().contains(metricName)) {
+            return Mono.just(toResponse(metricName, health.runHealthCheck(metricName)));
+        }
+        return Mono.empty();
+    }
+
+    private MonitorResponse toResponse(String name, Metric metric)
+    {
+        if (metric instanceof Counter) {
+            return new CounterResponse(name, (Counter) metric);
+        }
+        if (metric instanceof Gauge) {
+            return new GaugeResponse(name, (Gauge<?>) metric);
+        }
+        if (metric instanceof Histogram) {
+            return new HistogramResponse(name, (Histogram) metric);
+        }
+        if (metric instanceof Timer) {
+            return new TimerResponse(name, (Timer) metric);
+        }
+        if (metric instanceof Meter) {
+            return new MeterResponse(name, (Meter) metric);
+        }
+        throw new IllegalStateException("don't know how to handle '" + name + "': " + metric.getClass());
+    }
+
+    private MonitorResponse toResponse(String name, HealthCheck.Result result)
+    {
+        return new HealthCheckResponse(name, result);
+    }
+}

--- a/otj-metrics-reactive/src/main/java/com/opentable/metrics/reactive/MetricsHttpReactiveConfiguration.java
+++ b/otj-metrics-reactive/src/main/java/com/opentable/metrics/reactive/MetricsHttpReactiveConfiguration.java
@@ -1,0 +1,14 @@
+package com.opentable.metrics.reactive;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+
+import com.opentable.metrics.http.MetricsHttpCoreConfiguration;
+
+@Configuration
+@Import({
+        MetricsHttpCoreConfiguration.class,
+        MetricsHttpEndpoint.class,
+})
+public class MetricsHttpReactiveConfiguration {
+}

--- a/pom.xml
+++ b/pom.xml
@@ -40,6 +40,7 @@
         <module>otj-metrics-core</module>
         <module>otj-metrics-jaxrs</module>
         <module>otj-metrics-mvc</module>
+        <module>otj-metrics-reactive</module>
         <module>otj-metrics</module>
         <module>otj-metrics-actuator</module>
     </modules>
@@ -80,6 +81,11 @@
             <dependency>
                 <groupId>com.opentable.components</groupId>
                 <artifactId>otj-metrics-mvc</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.opentable.components</groupId>
+                <artifactId>otj-metrics-reactive</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>


### PR DESCRIPTION
The primary difference from otj-metrics-mvc is that these endpoints return a `Mono` of the response type.