### PR TITLE
Add a histogram endpoint to MetricSetBuilder

### DIFF
--- a/otj-metrics-core/src/main/java/com/opentable/metrics/MetricSetBuilder.java
+++ b/otj-metrics-core/src/main/java/com/opentable/metrics/MetricSetBuilder.java
@@ -26,6 +26,7 @@ import com.codahale.metrics.Meter;
 import com.codahale.metrics.Metric;
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.MetricSet;
+import com.codahale.metrics.Reservoir;
 import com.codahale.metrics.Timer;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
@@ -141,12 +142,22 @@ public class MetricSetBuilder {
     }
 
     /**
-     * Create a histogram
+     * Create a histogram using an {@link ExponentiallyDecayingReservoir}
      * @param name the name of the histogram to create
      * @return a new histogram
      */
     public Histogram histogram(String name) {
-        return create(name, () -> new Histogram(new ExponentiallyDecayingReservoir()));
+        return histogram(name, new ExponentiallyDecayingReservoir());
+    }
+
+    /**
+     * Create a histogram using with a specific reservoir
+     * @param name the name of the histogram to create
+     * @param reservoir the reservoir to use for collecting histogram data
+     * @return a new histogram
+     */
+    public Histogram histogram(String name, Reservoir reservoir) {
+        return create(name, () -> new Histogram(reservoir));
     }
 
     /**

--- a/otj-metrics-core/src/main/java/com/opentable/metrics/MetricSetBuilder.java
+++ b/otj-metrics-core/src/main/java/com/opentable/metrics/MetricSetBuilder.java
@@ -20,6 +20,8 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Supplier;
 
 import com.codahale.metrics.Counter;
+import com.codahale.metrics.ExponentiallyDecayingReservoir;
+import com.codahale.metrics.Histogram;
 import com.codahale.metrics.Meter;
 import com.codahale.metrics.Metric;
 import com.codahale.metrics.MetricRegistry;
@@ -136,6 +138,15 @@ public class MetricSetBuilder {
      */
     public AtomicLong longGauge(String name) {
         return create(name, AtomicLongGauge::new);
+    }
+
+    /**
+     * Create a histogram
+     * @param name the name of the histogram to create
+     * @return a new histogram
+     */
+    public Histogram histogram(String name) {
+        return create(name, () -> new Histogram(new ExponentiallyDecayingReservoir()));
     }
 
     /**

--- a/otj-metrics-core/src/test/java/com/opentable/metrics/MetricSetBuilderTest.java
+++ b/otj-metrics-core/src/test/java/com/opentable/metrics/MetricSetBuilderTest.java
@@ -20,6 +20,7 @@ import java.util.Map;
 
 import javax.management.MBeanServer;
 
+import com.codahale.metrics.Histogram;
 import com.codahale.metrics.Meter;
 import com.codahale.metrics.Metric;
 import com.codahale.metrics.MetricRegistry;
@@ -62,6 +63,19 @@ public class MetricSetBuilderTest {
         final MetricSetBuilder b = new MetricSetBuilder(testRegistry);
         b.setPrefix("test");
         final Meter foo = b.meter("foo");
+
+        assertThat(testRegistry.getMetrics()).isEmpty();
+        final Map<String, Metric> builtMetrics = b.build().getMetrics();
+        assertThat(builtMetrics).containsEntry("test.foo", foo);
+        assertThat(testRegistry.getMetrics()).isEqualTo(builtMetrics);
+    }
+
+    @Test
+    public void testHistogramRegisters() {
+        final MetricRegistry testRegistry = new MetricRegistry();
+        final MetricSetBuilder b = new MetricSetBuilder(testRegistry);
+        b.setPrefix("test");
+        final Histogram foo = b.histogram("foo");
 
         assertThat(testRegistry.getMetrics()).isEmpty();
         final Map<String, Metric> builtMetrics = b.build().getMetrics();

--- a/otj-metrics-core/src/test/java/com/opentable/metrics/MetricSetBuilderTest.java
+++ b/otj-metrics-core/src/test/java/com/opentable/metrics/MetricSetBuilderTest.java
@@ -25,6 +25,8 @@ import com.codahale.metrics.Meter;
 import com.codahale.metrics.Metric;
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.MetricSet;
+import com.codahale.metrics.Reservoir;
+import com.codahale.metrics.Snapshot;
 import com.codahale.metrics.Timer;
 
 import org.junit.Test;
@@ -81,6 +83,38 @@ public class MetricSetBuilderTest {
         final Map<String, Metric> builtMetrics = b.build().getMetrics();
         assertThat(builtMetrics).containsEntry("test.foo", foo);
         assertThat(testRegistry.getMetrics()).isEqualTo(builtMetrics);
+    }
+
+    @Test
+    public void testHistogramCreationWithReservoir() {
+        final Reservoir testReservoir = new Reservoir() {
+            @Override
+            public int size() {
+                return 0;
+            }
+
+            @Override
+            public void update(long value) {
+            }
+
+            @Override
+            public Snapshot getSnapshot() {
+                return null;
+            }
+        };
+        final MetricRegistry testRegistry = new MetricRegistry();
+        final MetricSetBuilder b = new MetricSetBuilder(testRegistry);
+        b.setPrefix("test");
+        b.histogram("foo", testReservoir);
+
+        final Map<String, Metric> builtMetrics = b.build().getMetrics();
+        assertThat(builtMetrics)
+            .extracting("test.foo")
+            .first()
+            .isInstanceOf(Histogram.class)
+            .extracting("reservoir")
+            .containsExactly(testReservoir)
+        ;
     }
 
     @Test(expected = IllegalArgumentException.class)


### PR DESCRIPTION
If there's a reason that `histogram()` was not previously added to `MetricSetBuilder`, feel free to close this PR (but I'd be interested to hear what the issue is)