### PR TITLE
Bridge Prometheus [Do not merge]

### DIFF
--- a/otj-metrics-core/pom.xml
+++ b/otj-metrics-core/pom.xml
@@ -36,10 +36,6 @@
             <version>0.6.0</version>
         </dependency>
         <dependency>
-            <groupId>javax.ws.rs</groupId>
-            <artifactId>javax.ws.rs-api</artifactId>
-        </dependency>
-        <dependency>
             <groupId>io.prometheus</groupId>
             <artifactId>simpleclient_dropwizard</artifactId>
             <version>0.6.0</version>

--- a/otj-metrics-core/pom.xml
+++ b/otj-metrics-core/pom.xml
@@ -26,6 +26,25 @@
 
     <dependencies>
         <dependency>
+            <groupId>io.prometheus</groupId>
+            <artifactId>simpleclient</artifactId>
+            <version>0.6.0</version>
+        </dependency>
+        <dependency>
+            <groupId>io.prometheus</groupId>
+            <artifactId>simpleclient_common</artifactId>
+            <version>0.6.0</version>
+        </dependency>
+        <dependency>
+            <groupId>javax.ws.rs</groupId>
+            <artifactId>javax.ws.rs-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.prometheus</groupId>
+            <artifactId>simpleclient_dropwizard</artifactId>
+            <version>0.6.0</version>
+        </dependency>
+        <dependency>
             <groupId>com.opentable.components</groupId>
             <artifactId>otj-core</artifactId>
         </dependency>

--- a/otj-metrics-core/src/main/java/com/opentable/metrics/prometheus/BridgeDropWizard.java
+++ b/otj-metrics-core/src/main/java/com/opentable/metrics/prometheus/BridgeDropWizard.java
@@ -7,13 +7,14 @@ import com.codahale.metrics.MetricRegistry;
 
 import io.prometheus.client.CollectorRegistry;
 import io.prometheus.client.dropwizard.DropwizardExports;
+import io.prometheus.client.dropwizard.samplebuilder.SampleBuilder;
 
 public class BridgeDropWizard {
     private final DropwizardExports dropwizardExports;
     private final CollectorRegistry collectorRegistry;
     @Inject
-    public BridgeDropWizard(MetricRegistry metricRegistry, CollectorRegistry collectorRegistry) {
-        this.dropwizardExports = new DropwizardExports(metricRegistry);
+    public BridgeDropWizard(MetricRegistry metricRegistry, CollectorRegistry collectorRegistry, SampleBuilder sampleBuilder) {
+        this.dropwizardExports = new DropwizardExports(metricRegistry, sampleBuilder);
         this.collectorRegistry = collectorRegistry;
     }
 

--- a/otj-metrics-core/src/main/java/com/opentable/metrics/prometheus/BridgeDropWizard.java
+++ b/otj-metrics-core/src/main/java/com/opentable/metrics/prometheus/BridgeDropWizard.java
@@ -1,0 +1,24 @@
+package com.opentable.metrics.prometheus;
+
+import javax.annotation.PostConstruct;
+import javax.inject.Inject;
+
+import com.codahale.metrics.MetricRegistry;
+
+import io.prometheus.client.CollectorRegistry;
+import io.prometheus.client.dropwizard.DropwizardExports;
+
+public class BridgeDropWizard {
+    private final DropwizardExports dropwizardExports;
+    private final CollectorRegistry collectorRegistry;
+    @Inject
+    public BridgeDropWizard(MetricRegistry metricRegistry, CollectorRegistry collectorRegistry) {
+        this.dropwizardExports = new DropwizardExports(metricRegistry);
+        this.collectorRegistry = collectorRegistry;
+    }
+
+    @PostConstruct
+    public void start() {
+        dropwizardExports.register(collectorRegistry);
+    }
+}

--- a/otj-metrics-core/src/main/java/com/opentable/metrics/prometheus/ExposeMetricsJAXRSResource.java
+++ b/otj-metrics-core/src/main/java/com/opentable/metrics/prometheus/ExposeMetricsJAXRSResource.java
@@ -1,0 +1,67 @@
+package com.opentable.metrics.prometheus;
+
+import java.io.IOException;
+import java.io.StringWriter;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.Response;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.prometheus.client.CollectorRegistry;
+import io.prometheus.client.exporter.common.TextFormat;
+
+@Path("/infra/prometheus")
+public class ExposeMetricsJAXRSResource {
+    private static final Logger LOG = LoggerFactory.getLogger(ExposeMetricsJAXRSResource.class);
+
+    private final CollectorRegistry collectorRegistry;
+
+    @Inject
+    public ExposeMetricsJAXRSResource(CollectorRegistry collectorRegistry) {
+        this.collectorRegistry = collectorRegistry;
+    }
+
+    @GET
+    @Produces(TextFormat.CONTENT_TYPE_004)
+    public Response getMetrics(@QueryParam("name")List<String> names) throws IOException {
+        LOG.info("Called!");
+        return commonCode(names);
+    }
+
+    @POST
+    @Produces(TextFormat.CONTENT_TYPE_004)
+    public Response postMetrics(@QueryParam("name")List<String> names) throws IOException {
+        return commonCode(names);
+    }
+
+    private Response commonCode(final List<String> names) throws IOException {
+        return Response.ok(writer(names)).build();
+    }
+
+    private String writer(final List<String> names) throws IOException {
+        StringWriter stringWriter = new StringWriter();
+        TextFormat.write004(stringWriter, collectorRegistry.filteredMetricFamilySamples(parse(names)));
+        String str = stringWriter.toString();
+        LOG.info("Got {}", str);
+        return str;
+    }
+
+    private Set<String> parse(List<String> names) {
+        if (names == null) {
+            return Collections.emptySet();
+        }
+        return new HashSet<>(names);
+    }
+
+}

--- a/otj-metrics-core/src/main/java/com/opentable/metrics/prometheus/PrometheusConfiguration.java
+++ b/otj-metrics-core/src/main/java/com/opentable/metrics/prometheus/PrometheusConfiguration.java
@@ -15,7 +15,7 @@ import io.prometheus.client.dropwizard.samplebuilder.SampleBuilder;
 public class PrometheusConfiguration {
     @Bean
     CollectorRegistry collectorRegistry() {
-        return new CollectorRegistry();
+        return new CollectorRegistry(true);
     }
 
     @Bean

--- a/otj-metrics-core/src/main/java/com/opentable/metrics/prometheus/PrometheusConfiguration.java
+++ b/otj-metrics-core/src/main/java/com/opentable/metrics/prometheus/PrometheusConfiguration.java
@@ -9,7 +9,6 @@ import io.prometheus.client.CollectorRegistry;
 @Configuration
 @Import({
         BridgeDropWizard.class,
-        ExposeMetricsJAXRSResource.class,
 })
 public class PrometheusConfiguration {
     @Bean

--- a/otj-metrics-core/src/main/java/com/opentable/metrics/prometheus/PrometheusConfiguration.java
+++ b/otj-metrics-core/src/main/java/com/opentable/metrics/prometheus/PrometheusConfiguration.java
@@ -5,6 +5,8 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 
 import io.prometheus.client.CollectorRegistry;
+import io.prometheus.client.dropwizard.samplebuilder.DefaultSampleBuilder;
+import io.prometheus.client.dropwizard.samplebuilder.SampleBuilder;
 
 @Configuration
 @Import({
@@ -14,5 +16,10 @@ public class PrometheusConfiguration {
     @Bean
     CollectorRegistry collectorRegistry() {
         return new CollectorRegistry();
+    }
+
+    @Bean
+    SampleBuilder sampleBuilder() {
+        return new DefaultSampleBuilder();
     }
 }

--- a/otj-metrics-core/src/main/java/com/opentable/metrics/prometheus/PrometheusConfiguration.java
+++ b/otj-metrics-core/src/main/java/com/opentable/metrics/prometheus/PrometheusConfiguration.java
@@ -1,0 +1,19 @@
+package com.opentable.metrics.prometheus;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+
+import io.prometheus.client.CollectorRegistry;
+
+@Configuration
+@Import({
+        BridgeDropWizard.class,
+        ExposeMetricsJAXRSResource.class,
+})
+public class PrometheusConfiguration {
+    @Bean
+    CollectorRegistry collectorRegistry() {
+        return new CollectorRegistry();
+    }
+}

--- a/otj-metrics-jaxrs/src/main/java/com/opentable/metrics/jaxrs/PrometheusJAXRSConfiguration.java
+++ b/otj-metrics-jaxrs/src/main/java/com/opentable/metrics/jaxrs/PrometheusJAXRSConfiguration.java
@@ -1,0 +1,14 @@
+package com.opentable.metrics.jaxrs;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+
+import com.opentable.metrics.prometheus.PrometheusConfiguration;
+
+@Configuration
+@Import({
+        PrometheusJAXRSConfiguration.class,
+        PrometheusConfiguration.class
+})
+public class PrometheusJAXRSConfiguration {
+}

--- a/otj-metrics-jaxrs/src/main/java/com/opentable/metrics/jaxrs/PrometheusJAXRSConfiguration.java
+++ b/otj-metrics-jaxrs/src/main/java/com/opentable/metrics/jaxrs/PrometheusJAXRSConfiguration.java
@@ -7,7 +7,7 @@ import com.opentable.metrics.prometheus.PrometheusConfiguration;
 
 @Configuration
 @Import({
-        PrometheusJAXRSConfiguration.class,
+        PrometheusJAXRSResource.class,
         PrometheusConfiguration.class
 })
 public class PrometheusJAXRSConfiguration {

--- a/otj-metrics-jaxrs/src/main/java/com/opentable/metrics/jaxrs/PrometheusJAXRSResource.java
+++ b/otj-metrics-jaxrs/src/main/java/com/opentable/metrics/jaxrs/PrometheusJAXRSResource.java
@@ -1,0 +1,67 @@
+package com.opentable.metrics.jaxrs;
+
+import java.io.IOException;
+import java.io.StringWriter;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.Response;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.prometheus.client.CollectorRegistry;
+import io.prometheus.client.exporter.common.TextFormat;
+
+@Path("/infra/prometheus")
+public class PrometheusJAXRSResource {
+    private static final Logger LOG = LoggerFactory.getLogger(PrometheusJAXRSResource.class);
+
+    private final CollectorRegistry collectorRegistry;
+
+    @Inject
+    public PrometheusJAXRSResource(CollectorRegistry collectorRegistry) {
+        this.collectorRegistry = collectorRegistry;
+    }
+
+    @GET
+    @Produces(TextFormat.CONTENT_TYPE_004)
+    public Response getMetrics(@QueryParam("name")List<String> names) throws IOException {
+        LOG.info("Called!");
+        return commonCode(names);
+    }
+
+    @POST
+    @Produces(TextFormat.CONTENT_TYPE_004)
+    public Response postMetrics(@QueryParam("name")List<String> names) throws IOException {
+        return commonCode(names);
+    }
+
+    private Response commonCode(final List<String> names) throws IOException {
+        return Response.ok(writer(names)).build();
+    }
+
+    private String writer(final List<String> names) throws IOException {
+        StringWriter stringWriter = new StringWriter();
+        TextFormat.write004(stringWriter, collectorRegistry.filteredMetricFamilySamples(parse(names)));
+        String str = stringWriter.toString();
+        LOG.info("Got {}", str);
+        return str;
+    }
+
+    private Set<String> parse(List<String> names) {
+        if (names == null) {
+            return Collections.emptySet();
+        }
+        return new HashSet<>(names);
+    }
+
+}

--- a/otj-metrics-mvc/src/main/java/com/opentable/metrics/mvc/PrometheusMVCConfiguration.java
+++ b/otj-metrics-mvc/src/main/java/com/opentable/metrics/mvc/PrometheusMVCConfiguration.java
@@ -7,7 +7,7 @@ import com.opentable.metrics.prometheus.PrometheusConfiguration;
 
 @Configuration
 @Import({
-        PrometheusMVCConfiguration.class,
+        PrometheusMVCResource.class,
         PrometheusConfiguration.class
 })
 public class PrometheusMVCConfiguration {

--- a/otj-metrics-mvc/src/main/java/com/opentable/metrics/mvc/PrometheusMVCConfiguration.java
+++ b/otj-metrics-mvc/src/main/java/com/opentable/metrics/mvc/PrometheusMVCConfiguration.java
@@ -1,0 +1,14 @@
+package com.opentable.metrics.mvc;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+
+import com.opentable.metrics.prometheus.PrometheusConfiguration;
+
+@Configuration
+@Import({
+        PrometheusMVCConfiguration.class,
+        PrometheusConfiguration.class
+})
+public class PrometheusMVCConfiguration {
+}

--- a/otj-metrics-mvc/src/main/java/com/opentable/metrics/mvc/PrometheusMVCResource.java
+++ b/otj-metrics-mvc/src/main/java/com/opentable/metrics/mvc/PrometheusMVCResource.java
@@ -1,4 +1,4 @@
-package com.opentable.metrics.prometheus;
+package com.opentable.metrics.mvc;
 
 import java.io.IOException;
 import java.io.StringWriter;
@@ -8,45 +8,43 @@ import java.util.List;
 import java.util.Set;
 
 import javax.inject.Inject;
-import javax.ws.rs.GET;
-import javax.ws.rs.POST;
-import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
-import javax.ws.rs.QueryParam;
-import javax.ws.rs.core.Response;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 
 import io.prometheus.client.CollectorRegistry;
 import io.prometheus.client.exporter.common.TextFormat;
 
-@Path("/infra/prometheus")
-public class ExposeMetricsJAXRSResource {
-    private static final Logger LOG = LoggerFactory.getLogger(ExposeMetricsJAXRSResource.class);
+@RequestMapping("/infra/prometheus")
+@RestController
+public class PrometheusMVCResource {
+    private static final Logger LOG = LoggerFactory.getLogger(PrometheusMVCResource.class);
 
     private final CollectorRegistry collectorRegistry;
 
     @Inject
-    public ExposeMetricsJAXRSResource(CollectorRegistry collectorRegistry) {
+    public PrometheusMVCResource(CollectorRegistry collectorRegistry) {
         this.collectorRegistry = collectorRegistry;
     }
 
-    @GET
-    @Produces(TextFormat.CONTENT_TYPE_004)
-    public Response getMetrics(@QueryParam("name")List<String> names) throws IOException {
+    @GetMapping(produces = TextFormat.CONTENT_TYPE_004)
+    public String getMetrics(@RequestParam("name")List<String> names) throws IOException {
         LOG.info("Called!");
         return commonCode(names);
     }
 
-    @POST
-    @Produces(TextFormat.CONTENT_TYPE_004)
-    public Response postMetrics(@QueryParam("name")List<String> names) throws IOException {
+    @PostMapping(produces = TextFormat.CONTENT_TYPE_004)
+    public String postMetrics(@RequestParam("name")List<String> names) throws IOException {
         return commonCode(names);
     }
 
-    private Response commonCode(final List<String> names) throws IOException {
-        return Response.ok(writer(names)).build();
+    private String commonCode(final List<String> names) throws IOException {
+        return writer(names);
     }
 
     private String writer(final List<String> names) throws IOException {

--- a/otj-metrics-reactive/src/main/java/com/opentable/metrics/reactive/PrometheusReactiveConfiguration.java
+++ b/otj-metrics-reactive/src/main/java/com/opentable/metrics/reactive/PrometheusReactiveConfiguration.java
@@ -7,7 +7,7 @@ import com.opentable.metrics.prometheus.PrometheusConfiguration;
 
 @Configuration
 @Import({
-        PrometheusReactiveConfiguration.class,
+        PrometheusReactiveResource.class,
         PrometheusConfiguration.class
 })
 public class PrometheusReactiveConfiguration {

--- a/otj-metrics-reactive/src/main/java/com/opentable/metrics/reactive/PrometheusReactiveConfiguration.java
+++ b/otj-metrics-reactive/src/main/java/com/opentable/metrics/reactive/PrometheusReactiveConfiguration.java
@@ -1,0 +1,14 @@
+package com.opentable.metrics.reactive;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+
+import com.opentable.metrics.prometheus.PrometheusConfiguration;
+
+@Configuration
+@Import({
+        PrometheusReactiveConfiguration.class,
+        PrometheusConfiguration.class
+})
+public class PrometheusReactiveConfiguration {
+}

--- a/otj-metrics-reactive/src/main/java/com/opentable/metrics/reactive/PrometheusReactiveResource.java
+++ b/otj-metrics-reactive/src/main/java/com/opentable/metrics/reactive/PrometheusReactiveResource.java
@@ -1,0 +1,65 @@
+package com.opentable.metrics.reactive;
+
+import java.io.IOException;
+import java.io.StringWriter;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import javax.inject.Inject;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import io.prometheus.client.CollectorRegistry;
+import io.prometheus.client.exporter.common.TextFormat;
+
+@RequestMapping("/infra/prometheus")
+@RestController
+public class PrometheusReactiveResource {
+    private static final Logger LOG = LoggerFactory.getLogger(PrometheusReactiveResource.class);
+
+    private final CollectorRegistry collectorRegistry;
+
+    @Inject
+    public PrometheusReactiveResource(CollectorRegistry collectorRegistry) {
+        this.collectorRegistry = collectorRegistry;
+    }
+
+    @GetMapping(produces = TextFormat.CONTENT_TYPE_004)
+    public String getMetrics(@RequestParam("name")List<String> names) throws IOException {
+        LOG.info("Called!");
+        return commonCode(names);
+    }
+
+    @PostMapping(produces = TextFormat.CONTENT_TYPE_004)
+    public String postMetrics(@RequestParam("name")List<String> names) throws IOException {
+        return commonCode(names);
+    }
+
+    private String commonCode(final List<String> names) throws IOException {
+        return writer(names);
+    }
+
+    private String writer(final List<String> names) throws IOException {
+        StringWriter stringWriter = new StringWriter();
+        TextFormat.write004(stringWriter, collectorRegistry.filteredMetricFamilySamples(parse(names)));
+        String str = stringWriter.toString();
+        LOG.info("Got {}", str);
+        return str;
+    }
+
+    private Set<String> parse(List<String> names) {
+        if (names == null) {
+            return Collections.emptySet();
+        }
+        return new HashSet<>(names);
+    }
+
+}


### PR DESCRIPTION
This is a sample showing it's pretty easy to bridge prometheus. There's an adapter provided by the Prometheus Java library, so it's just a matt3r of wiring this up and exposing.

Flaws in current implementation:
- while this has huge virtues (allows us to preserve dropwizard objects and annotations for now while shifting to prometheus), 
-  fundamentally it doesn't tackle the issues of tag model. There are some basic matchers in dropwizard adapter, but it's unlikely to fix everything automatically.

So it's more a curiosity.