### PR TITLE
Fix for: Factory method 'dropWizardHealthIndicator' threw exception; nested exception is java.lang.IllegalArgumentException: Beans must not be empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 otj-metrics
 ===========
 
+5.2.1
+-----
+* Fixes java.lang.IllegalArgumentException: Beans must not be empty
+
 5.2.0
 -----
 * Recompiled for Spring 5.2

--- a/otj-metrics-actuator/src/main/java/com/opentable/metrics/actuate/health/CodahaleHealthIndicatorConfiguration.java
+++ b/otj-metrics-actuator/src/main/java/com/opentable/metrics/actuate/health/CodahaleHealthIndicatorConfiguration.java
@@ -54,12 +54,12 @@ public class CodahaleHealthIndicatorConfiguration extends CompositeHealthContrib
      * @param checks Map of {@link HealthCheck} beans. Bean names as the key (Spring collections autowiring feature)
      */
     @Inject
-    CodahaleHealthIndicatorConfiguration(final Optional< Map<String, HealthCheck>> checks) {
+    CodahaleHealthIndicatorConfiguration(@SuppressWarnings("OptionalUsedAsFieldOrParameterType") final Optional< Map<String, HealthCheck>> checks) {
         dropWizardChecks = checks.orElse(Collections.emptyMap());
     }
 
     /**
-     * Creates {@link org.springframework.boot.actuate.health.CompositeHealthIndicator} bean which represents state of
+     * Creates {@link org.springframework.boot.actuate.health.CompositeHealthContributor} bean which represents state of
      * all injected {@link HealthCheck} beans. This bean is created conditionally, if there are no other  "dropWizardHealthIndicator"
      * defined in application context.
      *
@@ -68,7 +68,7 @@ public class CodahaleHealthIndicatorConfiguration extends CompositeHealthContrib
     @ConditionalOnMissingBean
     @Bean
     public HealthContributor dropWizardHealthIndicator() {
-        return createContributor(this.dropWizardChecks);
+        return createComposite(this.dropWizardChecks);
     }
 
     /**
@@ -94,5 +94,6 @@ public class CodahaleHealthIndicatorConfiguration extends CompositeHealthContrib
             return builder.build();
         }
     }
+
 
 }

--- a/otj-metrics-actuator/src/main/java/com/opentable/metrics/actuate/health/CodahaleHealthIndicatorConfiguration.java
+++ b/otj-metrics-actuator/src/main/java/com/opentable/metrics/actuate/health/CodahaleHealthIndicatorConfiguration.java
@@ -95,5 +95,4 @@ public class CodahaleHealthIndicatorConfiguration extends CompositeHealthContrib
         }
     }
 
-
 }


### PR DESCRIPTION
When context does not have HealthCheck beans.

Simpler implementation of the https://github.com/opentable/otj-metrics/pull/82