### PR TITLE
Customize prefix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,11 @@ otj-metrics
 
 5.2.3
 -----
-`ot.graphite.prefix` - defaults to app_metrics. *Normally you
+* Fix stray "-". Metrics were emitted in PL3 was
+  app_metrics.$env.$region.clustername--instance-5.... for example. Now
+  they correctly emit  app_metrics.$env.$region.clustername-instance-5...
+  
+* `ot.graphite.prefix` - defaults to app_metrics. *Normally you
 should never ever change this and please discuss with Visibility if you do*
 
 5.2.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 otj-metrics
 ===========
 
+5.2.3
+-----
+`ot.graphite.prefix` - defaults to app_metrics. *Normally you
+should never ever change this and please discuss with Visibility if you do*
+
 5.2.2
 -----
 * The health/ready endpoints had a scheduledexecutorservice not being shutdown

--- a/otj-metrics-core/src/main/java/com/opentable/metrics/graphite/GraphiteConfiguration.java
+++ b/otj-metrics-core/src/main/java/com/opentable/metrics/graphite/GraphiteConfiguration.java
@@ -184,7 +184,7 @@ public class GraphiteConfiguration {
                 }
                 case PART_OF_INSTANCE: {
                     return String.join(".", Arrays.asList(graphitePrefix, name,
-                            env.getType(), env.getLocation(), k8sInfo.getClusterName().get() + "- "+ instance));
+                            env.getType(), env.getLocation(), k8sInfo.getClusterName().get() + "-"+ instance));
                 }
                 case NONE: {
                     break; // effectively skips

--- a/otj-metrics-core/src/test/java/com/opentable/metrics/graphite/GraphiteReporterPrefixTest.java
+++ b/otj-metrics-core/src/test/java/com/opentable/metrics/graphite/GraphiteReporterPrefixTest.java
@@ -75,16 +75,30 @@ public class GraphiteReporterPrefixTest {
     }
 
     @Test
+    public void customizedPrefix() {
+        final String prefix = prefixFrom("mike_bell","prod-uswest2", "3", false);
+        Assert.assertNotNull(prefix);
+        Assert.assertEquals("mike_bell.test-server.prod.uswest2.instance-3", prefix);
+    }
+
+    @Test
     public void bad() {
         Assert.assertNull(prefixFrom(null, null,  null));
     }
 
     private String prefixFrom(final String env, final String instanceNo, Boolean includeFlavor) {
+        return prefixFrom(null, env, instanceNo, includeFlavor);
+    }
+
+    private String prefixFrom(final String prefix, final String env, final String instanceNo, Boolean includeFlavor) {
         final SpringApplication app = new SpringApplication(
                 TestConfiguration.class,
                 GraphiteConfiguration.class
         );
         final Map<String, Object> mockEnv = new HashMap<>();
+        if (prefix != null) {
+            mockEnv.put("ot.graphite.prefix", prefix);
+        }
         if (env != null) {
             if (includeFlavor != null) {
                 mockEnv.put("ot.graphite.reporting.include.flavors", includeFlavor);

--- a/otj-metrics-core/src/test/java/com/opentable/metrics/graphite/GraphiteReporterPrefixTest.java
+++ b/otj-metrics-core/src/test/java/com/opentable/metrics/graphite/GraphiteReporterPrefixTest.java
@@ -76,9 +76,16 @@ public class GraphiteReporterPrefixTest {
 
     @Test
     public void customizedPrefix() {
-        final String prefix = prefixFrom("mike_bell","prod-uswest2", "3", false);
+        final String prefix = prefixFrom(null, "mike_bell","prod-uswest2", "3", false);
         Assert.assertNotNull(prefix);
         Assert.assertEquals("mike_bell.test-server.prod.uswest2.instance-3", prefix);
+    }
+
+    @Test
+    public void customizedPrefixInK8s() {
+        final String prefix = prefixFrom("foo-ci-rs","mike_bell","prod-uswest2", "3", false);
+        Assert.assertNotNull(prefix);
+        Assert.assertEquals("mike_bell.test-server.prod.uswest2.foo-ci-rs-instance-3", prefix);
     }
 
     @Test
@@ -87,15 +94,20 @@ public class GraphiteReporterPrefixTest {
     }
 
     private String prefixFrom(final String env, final String instanceNo, Boolean includeFlavor) {
-        return prefixFrom(null, env, instanceNo, includeFlavor);
+        return prefixFrom(null,null, env, instanceNo, includeFlavor);
     }
 
-    private String prefixFrom(final String prefix, final String env, final String instanceNo, Boolean includeFlavor) {
+    private String prefixFrom(final String kubernetesCluster,
+                              final String prefix, final String env, final String instanceNo, Boolean includeFlavor) {
         final SpringApplication app = new SpringApplication(
                 TestConfiguration.class,
                 GraphiteConfiguration.class
         );
         final Map<String, Object> mockEnv = new HashMap<>();
+        if (kubernetesCluster != null) {
+            mockEnv.put("IS_KUBERNETES", "true");
+            mockEnv.put("K8S_CLUSTER_NAME", kubernetesCluster);
+        }
         if (prefix != null) {
             mockEnv.put("ot.graphite.prefix", prefix);
         }


### PR DESCRIPTION
Motivation: for the exercisers, relocate to a "heartbeat" prefix. See https://github.com/opentable/puppet-modules/pull/25402