### PR TITLE
update for jetty 10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 otj-metrics
 ===========
+6.0.0
+-----
+* Update Parent Pom to 362 [changes see here]( https://github.com/opentable/otj-parent/blob/master/CHANGELOG.md#362)
+* Jetty 2.7 / Jetty 10 is live!
 
 5.3.1
 ------

--- a/otj-metrics-actuator/pom.xml
+++ b/otj-metrics-actuator/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>otj-metrics-parent</artifactId>
         <groupId>com.opentable.components</groupId>
-        <version>5.3.2-SNAPSHOT</version>
+        <version>6.0.0</version>
     </parent>
 
     <properties>

--- a/otj-metrics-actuator/pom.xml
+++ b/otj-metrics-actuator/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>otj-metrics-parent</artifactId>
         <groupId>com.opentable.components</groupId>
-        <version>6.0.0</version>
+        <version>6.0.1-SNAPSHOT</version>
     </parent>
 
     <properties>

--- a/otj-metrics-core/pom.xml
+++ b/otj-metrics-core/pom.xml
@@ -111,7 +111,13 @@
 
         <dependency>
             <groupId>io.dropwizard.metrics</groupId>
-            <artifactId>metrics-jetty9</artifactId>
+            <artifactId>metrics-jetty10</artifactId>
+<!--            <exclusions>-->
+<!--                <exclusion>-->
+<!--                    <groupId>org.slf4j</groupId>-->
+<!--                    <artifactId>slf4j-api</artifactId>-->
+<!--                </exclusion>-->
+<!--            </exclusions>-->
         </dependency>
 
         <dependency>
@@ -142,6 +148,16 @@
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-server</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.eclipse.jetty.toolchain</groupId>
+                    <artifactId>jetty-servlet-api</artifactId>
+                </exclusion>
+<!--                <exclusion>    -->
+<!--                    <groupId>org.slf4j</groupId>-->
+<!--                    <artifactId>slf4j-api</artifactId>-->
+<!--                </exclusion>-->
+            </exclusions>
         </dependency>
 
         <dependency>
@@ -211,6 +227,13 @@
     <build>
         <pluginManagement>
             <plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-javadoc-plugin</artifactId>
+                    <configuration>
+                        <additionalOptions>-Xdoclint:none</additionalOptions>
+                    </configuration>
+                </plugin>
                 <plugin>
                     <groupId>com.mycila</groupId>
                     <artifactId>license-maven-plugin</artifactId>

--- a/otj-metrics-core/pom.xml
+++ b/otj-metrics-core/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>com.opentable.components</groupId>
         <artifactId>otj-metrics-parent</artifactId>
-        <version>5.3.2-SNAPSHOT</version>
+        <version>6.0.0-SNAPSHOT</version>
     </parent>
     <artifactId>otj-metrics-core</artifactId>
     <name>OpenTable Metrics Core</name>
@@ -232,6 +232,8 @@
                         </excludes>
                     </configuration>
                 </plugin>
+                <!-- temporary fix to ignore duplicates TODO: REMOVE in JETTY 10 update to parent pom-->
+
             </plugins>
         </pluginManagement>
     </build>

--- a/otj-metrics-core/pom.xml
+++ b/otj-metrics-core/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>com.opentable.components</groupId>
         <artifactId>otj-metrics-parent</artifactId>
-        <version>6.0.0</version>
+        <version>6.0.1-SNAPSHOT</version>
     </parent>
     <artifactId>otj-metrics-core</artifactId>
     <name>OpenTable Metrics Core</name>

--- a/otj-metrics-core/pom.xml
+++ b/otj-metrics-core/pom.xml
@@ -25,6 +25,7 @@
     <description>Manages metrics  and healthchecks and sends them to Graphite and exposes them via endpoints</description>
 
     <dependencies>
+
         <dependency>
             <groupId>com.opentable.components</groupId>
             <artifactId>otj-core</artifactId>
@@ -148,17 +149,12 @@
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-server</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.eclipse.jetty.toolchain</groupId>
-                    <artifactId>jetty-servlet-api</artifactId>
-                </exclusion>
-<!--                <exclusion>    -->
-<!--                    <groupId>org.slf4j</groupId>-->
-<!--                    <artifactId>slf4j-api</artifactId>-->
-<!--                </exclusion>-->
-            </exclusions>
         </dependency>
+
+<!--        <dependency>-->
+<!--            <groupId>org.eclipse.jetty.toolchain</groupId>-->
+<!--            <artifactId>jetty-servlet-api</artifactId>-->
+<!--        </dependency>-->
 
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
@@ -194,7 +190,9 @@
         <dependency>
             <groupId>javax.servlet</groupId>
             <artifactId>javax.servlet-api</artifactId>
+            <scope>runtime</scope>
         </dependency>
+
         <dependency>
             <groupId>javax.annotation</groupId>
             <artifactId>javax.annotation-api</artifactId>

--- a/otj-metrics-core/pom.xml
+++ b/otj-metrics-core/pom.xml
@@ -113,12 +113,6 @@
         <dependency>
             <groupId>io.dropwizard.metrics</groupId>
             <artifactId>metrics-jetty10</artifactId>
-<!--            <exclusions>-->
-<!--                <exclusion>-->
-<!--                    <groupId>org.slf4j</groupId>-->
-<!--                    <artifactId>slf4j-api</artifactId>-->
-<!--                </exclusion>-->
-<!--            </exclusions>-->
         </dependency>
 
         <dependency>
@@ -150,11 +144,6 @@
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-server</artifactId>
         </dependency>
-
-<!--        <dependency>-->
-<!--            <groupId>org.eclipse.jetty.toolchain</groupId>-->
-<!--            <artifactId>jetty-servlet-api</artifactId>-->
-<!--        </dependency>-->
 
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
@@ -190,7 +179,6 @@
         <dependency>
             <groupId>javax.servlet</groupId>
             <artifactId>javax.servlet-api</artifactId>
-            <scope>runtime</scope>
         </dependency>
 
         <dependency>
@@ -227,6 +215,8 @@
             <plugins>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
+                    <!-- this ignores the javadoc linting, currently a bunch of erroneous errors are thrown
+                    TODO remove and fix root cause -->
                     <artifactId>maven-javadoc-plugin</artifactId>
                     <configuration>
                         <additionalOptions>-Xdoclint:none</additionalOptions>

--- a/otj-metrics-core/pom.xml
+++ b/otj-metrics-core/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>com.opentable.components</groupId>
         <artifactId>otj-metrics-parent</artifactId>
-        <version>6.0.0-SNAPSHOT</version>
+        <version>6.0.0</version>
     </parent>
     <artifactId>otj-metrics-core</artifactId>
     <name>OpenTable Metrics Core</name>

--- a/otj-metrics-core/src/main/java/com/opentable/metrics/JettyServerMetricsConfiguration.java
+++ b/otj-metrics-core/src/main/java/com/opentable/metrics/JettyServerMetricsConfiguration.java
@@ -19,7 +19,7 @@ import java.util.function.Function;
 import javax.inject.Provider;
 
 import com.codahale.metrics.MetricRegistry;
-import com.codahale.metrics.jetty9.InstrumentedQueuedThreadPool;
+import io.dropwizard.metrics.jetty10.InstrumentedQueuedThreadPool;
 
 import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.Server;

--- a/otj-metrics-core/src/main/java/com/opentable/metrics/OTInstrumentedHandler.java
+++ b/otj-metrics-core/src/main/java/com/opentable/metrics/OTInstrumentedHandler.java
@@ -39,7 +39,7 @@ import org.eclipse.jetty.server.handler.HandlerWrapper;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 /**
- * Copy of Dropwizard Metrics {@link com.codahale.metrics.jetty9.InstrumentedHandler} which correctly records
+ * Copy of Dropwizard Metrics {@link io.dropwizard.metrics.jetty10.InstrumentedHandler} which correctly records
  * metrics about synchronous, asynchronous-suspended, and asynchronous-non-suspended requests.
  *
  * In any place where logic in this class does not match the Dropwizard InstrumentedHandler the logic was changed

--- a/otj-metrics-core/src/main/java/com/opentable/metrics/graphite/OtGraphiteReporter.java
+++ b/otj-metrics-core/src/main/java/com/opentable/metrics/graphite/OtGraphiteReporter.java
@@ -77,6 +77,7 @@ import org.slf4j.LoggerFactory;
  *
  * @see <a href="http://graphite.wikidot.com/">Graphite - Scalable Realtime Graphing</a>
  */
+@SuppressWarnings("PMD.UseTryWithResources")
 public class OtGraphiteReporter extends ScheduledReporter {
 
     /**

--- a/otj-metrics-micrometer/pom.xml
+++ b/otj-metrics-micrometer/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>otj-metrics-parent</artifactId>
         <groupId>com.opentable.components</groupId>
-        <version>5.3.2-SNAPSHOT</version>
+        <version>6.0.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/otj-metrics-micrometer/pom.xml
+++ b/otj-metrics-micrometer/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>otj-metrics-parent</artifactId>
         <groupId>com.opentable.components</groupId>
-        <version>6.0.0</version>
+        <version>6.0.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/otj-metrics-mvc/pom.xml
+++ b/otj-metrics-mvc/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>com.opentable.components</groupId>
         <artifactId>otj-metrics-parent</artifactId>
-        <version>6.0.0</version>
+        <version>6.0.1-SNAPSHOT</version>
     </parent>
     <artifactId>otj-metrics-mvc</artifactId>
     <name>OpenTable Metrics MVC</name>

--- a/otj-metrics-mvc/pom.xml
+++ b/otj-metrics-mvc/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>com.opentable.components</groupId>
         <artifactId>otj-metrics-parent</artifactId>
-        <version>5.3.2-SNAPSHOT</version>
+        <version>6.0.0</version>
     </parent>
     <artifactId>otj-metrics-mvc</artifactId>
     <name>OpenTable Metrics MVC</name>

--- a/otj-metrics-reactive/pom.xml
+++ b/otj-metrics-reactive/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>com.opentable.components</groupId>
         <artifactId>otj-metrics-parent</artifactId>
-        <version>5.3.2-SNAPSHOT</version>
+        <version>6.0.0-SNAPSHOT</version>
     </parent>
     <artifactId>otj-metrics-reactive</artifactId>
     <name>OpenTable Metrics Reactive</name>

--- a/otj-metrics-reactive/pom.xml
+++ b/otj-metrics-reactive/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>com.opentable.components</groupId>
         <artifactId>otj-metrics-parent</artifactId>
-        <version>6.0.0-SNAPSHOT</version>
+        <version>6.0.0</version>
     </parent>
     <artifactId>otj-metrics-reactive</artifactId>
     <name>OpenTable Metrics Reactive</name>

--- a/otj-metrics-reactive/pom.xml
+++ b/otj-metrics-reactive/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>com.opentable.components</groupId>
         <artifactId>otj-metrics-parent</artifactId>
-        <version>6.0.0</version>
+        <version>6.0.1-SNAPSHOT</version>
     </parent>
     <artifactId>otj-metrics-reactive</artifactId>
     <name>OpenTable Metrics Reactive</name>

--- a/otj-metrics/pom.xml
+++ b/otj-metrics/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>com.opentable.components</groupId>
         <artifactId>otj-metrics-parent</artifactId>
-        <version>5.2.5-SNAPSHOT</version>
+        <version>6.0.0-SNAPSHOT</version>
     </parent>
     <artifactId>otj-metrics</artifactId>
     <name>OpenTable Metrics - Legacy Relocation Artifact</name>

--- a/pom.xml
+++ b/pom.xml
@@ -50,6 +50,13 @@
         <dep.otj-conservedheaders.version>5.2.4</dep.otj-conservedheaders.version>
         <dep.otj-logging.version>5.3.1</dep.otj-logging.version>
         <!-- end remove -->
+
+        <basepom.check.fail-dependency>false</basepom.check.fail-dependency>
+        <basepom.check.skip-duplicate-finder>true</basepom.check.skip-duplicate-finder>
+        <basepom.check.fail-dependency-management>false</basepom.check.fail-dependency-management>
+        <basepom.check.fail-dependency-scope>false</basepom.check.fail-dependency-scope>
+        <basepom.check.fail-dependency-versions-check>false</basepom.check.fail-dependency-versions-check>
+        <dep.otj-logging.version>5.3.2-SNAPSHOT</dep.otj-logging.version>
         <!-- This wasn't managed before but should have been -->
         <!-- Last non forked release was 3.1.3, we now start at 3.9.9, the next release being 3.9.9.1, etc -->
         <!-- As this is forked, please see the opentable/metrics-spring-1 repo for source -->

--- a/pom.xml
+++ b/pom.xml
@@ -51,15 +51,17 @@
         <dep.otj-logging.version>5.3.1</dep.otj-logging.version>
         <!-- end remove -->
 
-        <basepom.check.fail-dependency>false</basepom.check.fail-dependency>
-        <basepom.check.skip-duplicate-finder>true</basepom.check.skip-duplicate-finder>
-        <basepom.check.fail-dependency-management>false</basepom.check.fail-dependency-management>
-        <basepom.check.fail-dependency-scope>false</basepom.check.fail-dependency-scope>
-        <basepom.check.fail-dependency-versions-check>false</basepom.check.fail-dependency-versions-check>
-        <dep.otj-logging.version>5.3.2-SNAPSHOT</dep.otj-logging.version>
+<!--        <basepom.check.fail-dependency>false</basepom.check.fail-dependency>-->
+<!--        <basepom.check.skip-duplicate-finder>true</basepom.check.skip-duplicate-finder>-->
+<!--        <basepom.check.fail-dependency-management>false</basepom.check.fail-dependency-management>-->
+<!--        <basepom.check.fail-dependency-scope>false</basepom.check.fail-dependency-scope>-->
+<!--        <basepom.check.fail-dependency-versions-check>false</basepom.check.fail-dependency-versions-check>-->
+<!--        <dep.otj-logging.version>5.3.2-SNAPSHOT</dep.otj-logging.version>-->
         <!-- This wasn't managed before but should have been -->
         <!-- Last non forked release was 3.1.3, we now start at 3.9.9, the next release being 3.9.9.1, etc -->
         <!-- As this is forked, please see the opentable/metrics-spring-1 repo for source -->
+        <dep.javax.servlet-api.version>4.0.1</dep.javax.servlet-api.version>
+        <dep.jetty-servlet-api.version>4.0.6</dep.jetty-servlet-api.version>
         <dep.metrics-spring.version>3.9.9</dep.metrics-spring.version>
         <basepom.oss.skip-scala-doc>true</basepom.oss.skip-scala-doc>
         <basepom.check.skip-javadoc>false</basepom.check.skip-javadoc>
@@ -68,6 +70,43 @@
 
     <dependencyManagement>
         <dependencies>
+            <dependency>
+                <groupId>javax.servlet</groupId>
+                <artifactId>javax.servlet-api</artifactId>
+                <version>${dep.javax.servlet-api.version}</version>
+<!--                <scope>compile</scope>-->
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.jetty</groupId>
+                <artifactId>jetty-server</artifactId>
+                <version>10.0.12</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.eclipse.jetty.toolchain</groupId>
+                        <artifactId>jetty-servlet-api</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.slf4j</groupId>
+                        <artifactId>slf4j-api</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>io.dropwizard.metrics</groupId>
+                <artifactId>metrics-jetty10</artifactId>
+                <version>4.2.13</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.slf4j</groupId>
+                        <artifactId>slf4j-api</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+<!--            <dependency>-->
+<!--                <groupId>org.eclipse.jetty.toolchain</groupId>-->
+<!--                <artifactId>jetty-servlet-api</artifactId>-->
+<!--                <version>${dep.jetty-servlet-api.version}</version>-->
+<!--            </dependency>-->
             <dependency>
                 <groupId>com.ryantenney.metrics</groupId>
                 <artifactId>metrics-spring</artifactId>
@@ -78,11 +117,14 @@
                 <version>${dep.metrics-spring.version}</version>
             </dependency>
 
+
             <dependency>
                 <groupId>com.opentable.components</groupId>
                 <artifactId>otj-metrics-core</artifactId>
                 <version>${project.version}</version>
             </dependency>
+
+
 <!--            <dependency>-->
 <!--                <groupId>com.opentable.components</groupId>-->
 <!--                <artifactId>otj-metrics-jaxrs</artifactId>-->

--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,6 @@
         <!-- Last non forked release was 3.1.3, we now start at 3.9.9, the next release being 3.9.9.1, etc -->
         <!-- As this is forked, please see the opentable/metrics-spring-1 repo for source -->
         <dep.javax.servlet-api.version>4.0.1</dep.javax.servlet-api.version>
-        <dep.jetty-servlet-api.version>4.0.6</dep.jetty-servlet-api.version>
         <dep.metrics-spring.version>3.9.9</dep.metrics-spring.version>
         <basepom.oss.skip-scala-doc>true</basepom.oss.skip-scala-doc>
         <basepom.check.skip-javadoc>false</basepom.check.skip-javadoc>
@@ -76,10 +75,12 @@
                 <version>${dep.javax.servlet-api.version}</version>
 <!--                <scope>compile</scope>-->
             </dependency>
+            <!-- this is here to exclude the jetty-servlet-api in favour of the javax.servlet-api, which in theory
+         should be the same, some jetty 11 will need to be jakarta-->
             <dependency>
                 <groupId>org.eclipse.jetty</groupId>
                 <artifactId>jetty-server</artifactId>
-                <version>10.0.12</version>
+                <version>${dep.jetty.version}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>org.eclipse.jetty.toolchain</groupId>
@@ -91,22 +92,27 @@
                     </exclusion>
                 </exclusions>
             </dependency>
+            <!-- this is here to exclude the jetty-servlet-api in favour of the javax.servlet-api, which in theory
+            should be the same, some jetty 11 will need to be jakarta, this overrides the managed dependencies in
+            io.dropwizard.metrics:metrics-parent , where metrics-jetty10 gets the versioning from.
+            dep.metrics4.version gets its value from otj-parent
+            -->
             <dependency>
                 <groupId>io.dropwizard.metrics</groupId>
                 <artifactId>metrics-jetty10</artifactId>
-                <version>4.2.13</version>
+                <version>${dep.metrics4.version}</version>
                 <exclusions>
+                    <exclusion>
+                        <groupId>org.eclipse.jetty.toolchain</groupId>
+                        <artifactId>jetty-servlet-api</artifactId>
+                    </exclusion>
                     <exclusion>
                         <groupId>org.slf4j</groupId>
                         <artifactId>slf4j-api</artifactId>
                     </exclusion>
                 </exclusions>
             </dependency>
-<!--            <dependency>-->
-<!--                <groupId>org.eclipse.jetty.toolchain</groupId>-->
-<!--                <artifactId>jetty-servlet-api</artifactId>-->
-<!--                <version>${dep.jetty-servlet-api.version}</version>-->
-<!--            </dependency>-->
+
             <dependency>
                 <groupId>com.ryantenney.metrics</groupId>
                 <artifactId>metrics-spring</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -26,13 +26,13 @@
         <connection>scm:git:git://github.com/opentable/otj-metrics.git</connection>
         <developerConnection>scm:git:git@github.com:opentable/otj-metrics.git</developerConnection>
         <url>http://github.com/opentable/otj-metrics</url>
-        <tag>HEAD</tag>
+        <tag>otj-metrics-parent-6.0.0</tag>
     </scm>
 
     <groupId>com.opentable.components</groupId>
     <artifactId>otj-metrics-parent</artifactId>
     <name>OpenTable Metrics - Parent</name>
-    <version>6.0.0-SNAPSHOT</version>
+    <version>6.0.0</version>
     <packaging>pom</packaging>
     <description>OpenTable Metrics - Parent</description>
 

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
     <groupId>com.opentable.components</groupId>
     <artifactId>otj-metrics-parent</artifactId>
     <name>OpenTable Metrics - Parent</name>
-    <version>6.0.0</version>
+    <version>6.0.1-SNAPSHOT</version>
     <packaging>pom</packaging>
     <description>OpenTable Metrics - Parent</description>
 

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>com.opentable</groupId>
         <artifactId>otj-parent-spring</artifactId>
-        <version>361-SNAPSHOT</version>
+        <version>362</version>
     </parent>
 
     <scm>
@@ -32,7 +32,7 @@
     <groupId>com.opentable.components</groupId>
     <artifactId>otj-metrics-parent</artifactId>
     <name>OpenTable Metrics - Parent</name>
-    <version>5.3.2-SNAPSHOT</version>
+    <version>6.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <description>OpenTable Metrics - Parent</description>
 
@@ -65,31 +65,21 @@
         <basepom.oss.skip-scala-doc>true</basepom.oss.skip-scala-doc>
         <basepom.check.skip-javadoc>false</basepom.check.skip-javadoc>
         <basepom.check.fail-javadoc>false</basepom.check.fail-javadoc>
+        <!-- override jetty9 in parent 9 in old pom
+some are redundant but better safe than sorry TODO: REMOVE ON PARENT UPDATE -->
+        <dep.jetty.version>10.0.12.1</dep.jetty.version>
+        <dep.jetty-server.version>10.0.12</dep.jetty-server.version>
+        <dep.otj-scopes.version>6.0.0</dep.otj-scopes.version>
+        <dep.otj-httpheaders.version>6.0.0</dep.otj-httpheaders.version>
+        <dep.otj-http-common.version>6.0.0</dep.otj-http-common.version>
+        <dep.otj-spring.version>6.0.0</dep.otj-spring.version>
+        <dep.otj-jvm.version>6.0.0</dep.otj-jvm.version>
+        <!-- override end -->
+
     </properties>
 
     <dependencyManagement>
         <dependencies>
-            <!-- this is here to exclude the jetty-servlet-api in favour of the javax.servlet-api, which in theory
-            should be the same, some jetty 11 will need to be jakarta, this overrides the managed dependencies in
-            io.dropwizard.metrics:metrics-parent , where metrics-jetty10 gets the versioning from.
-            dep.metrics4.version gets its value from otj-parent
-            -->
-            <dependency>
-                <groupId>io.dropwizard.metrics</groupId>
-                <artifactId>metrics-jetty10</artifactId>
-                <version>${dep.metrics4.version}</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>org.eclipse.jetty.toolchain</groupId>
-                        <artifactId>jetty-servlet-api</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>org.slf4j</groupId>
-                        <artifactId>slf4j-api</artifactId>
-                    </exclusion>
-                </exclusions>
-            </dependency>
-
             <dependency>
                 <groupId>com.ryantenney.metrics</groupId>
                 <artifactId>metrics-spring</artifactId>
@@ -100,13 +90,11 @@
                 <version>${dep.metrics-spring.version}</version>
             </dependency>
 
-
             <dependency>
                 <groupId>com.opentable.components</groupId>
                 <artifactId>otj-metrics-core</artifactId>
                 <version>${project.version}</version>
             </dependency>
-
 
 <!--            <dependency>-->
 <!--                <groupId>com.opentable.components</groupId>-->
@@ -133,6 +121,23 @@
                 <artifactId>otj-metrics-micrometer</artifactId>
                 <version>${project.version}</version>
             </dependency>
+            <!-- mitigation to remove jetty-servlet-api conflict TODO: REMOVE on parent pom update -->
+            <dependency>
+                <groupId>io.dropwizard.metrics</groupId>
+                <artifactId>metrics-jetty10</artifactId>
+                <version>${dep.metrics4.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.eclipse.jetty.toolchain</groupId>
+                        <artifactId>jetty-servlet-api</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.slf4j</groupId>
+                        <artifactId>slf4j-api</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <!--  end mitigation to remove jetty-servlet-api conflict TODO: REMOVE on parent pom update -->
         </dependencies>
     </dependencyManagement>
 

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>com.opentable</groupId>
         <artifactId>otj-parent-spring</artifactId>
-        <version>358-SNAPSHOT</version>
+        <version>361-SNAPSHOT</version>
     </parent>
 
     <scm>
@@ -60,7 +60,7 @@
         <!-- This wasn't managed before but should have been -->
         <!-- Last non forked release was 3.1.3, we now start at 3.9.9, the next release being 3.9.9.1, etc -->
         <!-- As this is forked, please see the opentable/metrics-spring-1 repo for source -->
-        <dep.javax.servlet-api.version>4.0.1</dep.javax.servlet-api.version>
+<!--        <dep.javax.servlet-api.version>4.0.1</dep.javax.servlet-api.version>-->
         <dep.metrics-spring.version>3.9.9</dep.metrics-spring.version>
         <basepom.oss.skip-scala-doc>true</basepom.oss.skip-scala-doc>
         <basepom.check.skip-javadoc>false</basepom.check.skip-javadoc>
@@ -69,29 +69,6 @@
 
     <dependencyManagement>
         <dependencies>
-            <dependency>
-                <groupId>javax.servlet</groupId>
-                <artifactId>javax.servlet-api</artifactId>
-                <version>${dep.javax.servlet-api.version}</version>
-<!--                <scope>compile</scope>-->
-            </dependency>
-            <!-- this is here to exclude the jetty-servlet-api in favour of the javax.servlet-api, which in theory
-         should be the same, some jetty 11 will need to be jakarta-->
-            <dependency>
-                <groupId>org.eclipse.jetty</groupId>
-                <artifactId>jetty-server</artifactId>
-                <version>${dep.jetty.version}</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>org.eclipse.jetty.toolchain</groupId>
-                        <artifactId>jetty-servlet-api</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>org.slf4j</groupId>
-                        <artifactId>slf4j-api</artifactId>
-                    </exclusion>
-                </exclusions>
-            </dependency>
             <!-- this is here to exclude the jetty-servlet-api in favour of the javax.servlet-api, which in theory
             should be the same, some jetty 11 will need to be jakarta, this overrides the managed dependencies in
             io.dropwizard.metrics:metrics-parent , where metrics-jetty10 gets the versioning from.

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>com.opentable</groupId>
         <artifactId>otj-parent-spring</artifactId>
-        <version>344</version>
+        <version>358-SNAPSHOT</version>
     </parent>
 
     <scm>


### PR DESCRIPTION
DO NOT MERGE

https://opentable.atlassian.net/browse/OTPL-6933

Running PR for updated to jetty 10:

- InstrumentedQueuedThreadPool updated, uses different package, also requires slf4j2
- jetty-server requires slfj2 as well
- javadoc update, also had to disable linting temporarily, seems to throw errors where it doesn't seem there should be
- excluded jetty-servlet-api 2nd, 3rd, 4th nth try 

