### PR TITLE
Latest Java17 NMT fix proposal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 otj-metrics
 ===========
+
+6.0.1
+-----
+* Substantial rewrite to `NmtMetrics` to handle some breaking issues in Java 17.0.8
+
 6.0.0
 -----
 * Update Parent Pom to 362 [changes see here]( https://github.com/opentable/otj-parent/blob/master/CHANGELOG.md#362)

--- a/otj-metrics-core/src/main/java/com/opentable/metrics/jvm/NmtMetrics.java
+++ b/otj-metrics-core/src/main/java/com/opentable/metrics/jvm/NmtMetrics.java
@@ -14,59 +14,41 @@
 package com.opentable.metrics.jvm;
 
 import java.time.Duration;
-import java.time.Instant;
-import java.util.HashSet;
+import java.util.Collections;
 import java.util.Locale;
-import java.util.Set;
-import java.util.function.Supplier;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
 
 import com.codahale.metrics.Gauge;
 import com.codahale.metrics.MetricRegistry;
-import com.google.common.base.Preconditions;
-import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Sets;
-import com.google.common.collect.Sets.SetView;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
 
 import com.opentable.jvm.Memory;
-import com.opentable.jvm.Nmt;
 
 /**
  * If JVM argument {@code -XX:NativeMemoryTracking=summary} is present, will register NMT-related metrics.
  * If not, won't do anything.
  *
- * As the lifetime of a process goes on, NMT returns increasingly more categories of information when you query it.
- * This means that at the outset, we do not know the complete set of gauges to register.  Given how DropWizard works,
- * the lightest-weight opportunity we have to identify new metrics is when the gauge functions are called.
- * Furthermore, this is also the opportunity to ensure that we are reading the latest NMT values.  However, fetching
- * NMT information is non-trivial, so we want to rate-limit it.  Therefore, the design employed here is that on gauge
- * measurement, we check to update our NMT observations according to a refresh period.  Having refreshed the NMT
- * information, we can <em>also</em> check for further metrics to register.
- *
- * Cf. https://docs.oracle.com/javase/8/docs/technotes/guides/troubleshoot/tooldescr022.html
- *
- * In terms of thread-safety, we assume the worst, and handle {@link #register()} and the gauge functions being called
- * by arbitrary threads.
- *
- * FindBugs is bad at understanding the synchronized access and modification of {@link #nmt}, particularly when
- * referred to in lambdas, so we suppress {@code IS2_INCONSISTENT_SYNC} warnings.
  */
-@SuppressFBWarnings(value = "IS2_INCONSISTENT_SYNC",
-        justification = "FindBugs gets confused by the lambda references to nmt.")
 public class NmtMetrics {
-    private static final Logger LOG = LoggerFactory.getLogger(NmtMetrics.class);
     private static final Duration REFRESH_PERIOD = Duration.ofSeconds(10);
 
     private final String prefix;
     private final MetricRegistry metrics;
-    private final Set<String> registeredMetrics = new HashSet<>();
 
-    private Nmt nmt;
-    private Instant lastRefresh;
+    private final ScheduledExecutorService exec = Executors.newScheduledThreadPool(
+        1,
+        new ThreadFactoryBuilder()
+            .setNameFormat("nmt-fetcher-%d")
+            .build()
+    );
+
+    private final ConcurrentMap<String, AtomicLong> gauges = new ConcurrentHashMap<>();
 
     public NmtMetrics(final String metricNamePrefix, final MetricRegistry metrics) {
         prefix = metricNamePrefix;
@@ -74,68 +56,30 @@ public class NmtMetrics {
     }
 
     public synchronized void register() {
-        nmt = Memory.getNmt();
-        if (nmt == null) {
-            LOG.info("got null NMT info; not registering any metrics");
-            return;
-        }
-        lastRefresh = Instant.now();
-        refreshCategories();
-        if (registeredMetrics.isEmpty()) {
-            LOG.warn("Didn't find any NMT metrics to register!");
-        }
-        registerGauges("total", () -> nmt.total);
+        exec.scheduleAtFixedRate(this::poll, 0, REFRESH_PERIOD.toMillis(), TimeUnit.MILLISECONDS);
     }
 
-    private void refreshCategories() {
-        final Set<String> atStart = ImmutableSet.copyOf(registeredMetrics);
-        nmt.categories.keySet().forEach(categoryName -> {
-            final String metricName = categoryName.toLowerCase(Locale.ROOT).replaceAll(" ", "-");
-            if (registeredMetrics.contains(metricName)) {
+    private void setGaugeValue(String metricName, long value) {
+        AtomicLong gauge = this.gauges.get(metricName);
+        if (gauge == null) {
+            AtomicLong newGauge = new AtomicLong(value);
+            gauge = this.gauges.putIfAbsent(metricName, newGauge);
+            if (gauge == null) {
+                metrics.register(metricName, (Gauge<Long>) newGauge::longValue);
                 return;
             }
-            registerCategoryGauges(metricName, categoryName);
-        });
-        final SetView<String> added = Sets.difference(registeredMetrics, atStart);
-        if (!added.isEmpty()) {
-            LOG.debug("Registered metrics: {}", added);
         }
+        gauge.set(value);
     }
 
-    private void refreshNmt() {
-        final Instant now = Instant.now();
-        if (now.isBefore(lastRefresh.plus(REFRESH_PERIOD))) {
-            return;
-        }
-        nmt = Memory.getNmt();
-        Preconditions.checkNotNull(nmt);
-        lastRefresh = now;
-        refreshCategories();
-    }
-
-    private void registerGauges(final String metricName, final Supplier<Nmt.Usage> usageSupplier) {
-        if (!registeredMetrics.add(metricName)) {
-            throw new IllegalStateException(String.format("%s already registered", metricName));
-        }
-
-        final String fullMetricName = prefix + "." + metricName;
-
-        metrics.register(fullMetricName + ".reserved", (Gauge<Long>)() -> {
-            synchronized (this) {
-                refreshNmt();
-                return usageSupplier.get().reserved;
-            }
-        });
-
-        metrics.register(fullMetricName + ".committed", (Gauge<Long>)() -> {
-            synchronized (this) {
-                refreshNmt();
-                return usageSupplier.get().committed;
-            }
-        });
-    }
-
-    private void registerCategoryGauges(final String metricName, final String categoryName) {
-        registerGauges(metricName, () -> nmt.categories.get(categoryName));
+    private void poll() {
+        Optional.ofNullable(Memory.getNmt())
+            .map(i -> i.categories)
+            .orElse(Collections.emptyMap())
+            .forEach((key, value) -> {
+                final String fullMetricName = prefix + "." + key.toLowerCase(Locale.ROOT).replaceAll(" ", "-");
+                setGaugeValue(fullMetricName + ".reserved", value.reserved);
+                setGaugeValue(fullMetricName + ".committed", value.committed);
+            });
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
         <connection>scm:git:git://github.com/opentable/otj-metrics.git</connection>
         <developerConnection>scm:git:git@github.com:opentable/otj-metrics.git</developerConnection>
         <url>http://github.com/opentable/otj-metrics</url>
-        <tag>otj-metrics-parent-6.0.0</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <groupId>com.opentable.components</groupId>


### PR DESCRIPTION
In latest Java some NMT categories can disappear from set. I've noticed this behavior with "Tracing" category.  I suggest slightly simplify process:
* Fetch NMT periodically instead of rate limiting
* Cache gauge values instead set of categories, so they can keep last reported value